### PR TITLE
Expressions enhancements

### DIFF
--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.As.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.As.vb
@@ -3,14 +3,10 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateAs(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
-
-      If entityCount < limit Then
-        For i = 1 To entityCount - 1
-          GenerateAsWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+      For i = 1 To entityCount - 1
+        GenerateAsWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 2 < entityCount Then
         GenerateAsWithPredicateWithIJoin(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Exclude.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Exclude.vb
@@ -3,14 +3,10 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateExclude(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
-
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateExcludeWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+      For i = 1 To entityCount
+        GenerateExcludeWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         GenerateExcludeWithPredicateWithIJoin(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.GroupBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.GroupBy.vb
@@ -3,14 +3,10 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateGroupBy(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
-
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateGroupByWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+      For i = 1 To entityCount
+        GenerateGroupByWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         If entityCount < 8 Then

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Having.And.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Having.And.vb
@@ -3,17 +3,13 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateHavingAnd(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
+      For i = 1 To entityCount
+        GenerateHavingAndWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
 
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateHavingAndWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-
-          GenerateHavingAndWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+        GenerateHavingAndWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         If entityCount < 4 Then

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Having.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Having.vb
@@ -3,17 +3,13 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateHaving(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
+      For i = 1 To entityCount
+        GenerateHavingWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
 
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateHavingWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-
-          GenerateHavingWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+        GenerateHavingWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         If entityCount < 4 Then

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Include.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Include.vb
@@ -3,21 +3,17 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateInclude(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 5
+      For i = 1 To entityCount
+        GenerateIncludeWithActionWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateIncludeWithActionWithOneEntity(builder, i, entityCount)
+      For i = 1 To entityCount
+        For j = 1 To entityCount
+          GenerateIncludeWithKeyValueSelectorsWithOneEntity(builder, i, j, entityCount)
           builder.AppendLine()
         Next
-
-        For i = 1 To entityCount
-          For j = 1 To entityCount
-            GenerateIncludeWithKeyValueSelectorsWithOneEntity(builder, i, j, entityCount)
-            builder.AppendLine()
-          Next
-        Next
-      End If
+      Next
 
       If 1 < entityCount Then
         GenerateIncludeWithActionWithIJoin(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.OrderBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.OrderBy.vb
@@ -6,20 +6,32 @@
       For i = 1 To entityCount
         GenerateOrderByWithPredicateWithOneEntity(builder, i, entityCount)
         builder.AppendLine()
+
+        GenerateOrderByWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
+        builder.AppendLine()
       Next
 
       If 1 < entityCount Then
         GenerateOrderByWithPredicateWithIJoin(builder, entityCount)
+        builder.AppendLine()
+
+        GenerateOrderByWithPredicateWithIJoinReturningFormattableString(builder, entityCount)
         builder.AppendLine()
       End If
 
       For i = 1 To entityCount
         GenerateOrderByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
         builder.AppendLine()
+
+        GenerateOrderByDescendingWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
+        builder.AppendLine()
       Next
 
       If 1 < entityCount Then
         GenerateOrderByDescendingWithPredicateWithIJoin(builder, entityCount)
+        builder.AppendLine()
+
+        GenerateOrderByDescendingWithPredicateWithIJoinReturningFormattableString(builder, entityCount)
         builder.AppendLine()
       End If
 
@@ -36,13 +48,20 @@
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
       builder.Indent().AppendLine($"Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of {generic}, TKey))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalOrderBy(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, True)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
 
-      If entityCount = 1 Then
-        builder.Indent().AppendLine($"Return InternalOrderBy(Of TKey)(keySelector, True)").PopIndent()
-      Else
-        builder.Indent().AppendLine($"Return InternalOrderBy(Of TKey)(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, True)").PopIndent()
-      End If
+    Protected Sub GenerateOrderByWithPredicateWithOneEntityReturningFormattableString(builder As CodeBuilder, index As Int32, entityCount As Int32)
+      Dim comment = "Adds ORDER BY clause."
+      Dim params = {"keySelector"}
+      AddComment(builder, comment, params:=params, returns:="")
 
+      Dim generic = GetGenericName(index, index = entityCount)
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function OrderBy(keySelector As Expression(Of Func(Of {generic}, FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalOrderBy(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, True)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -55,7 +74,19 @@
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
       builder.Indent().AppendLine($"Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of {generics}), TKey))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)").PopIndent()
+      builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, True)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateOrderByWithPredicateWithIJoinReturningFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds ORDER BY clause."
+      Dim params = {"keySelector"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of {generics}), FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, True)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -69,13 +100,20 @@
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
       builder.Indent().AppendLine($"Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of {generic}, TKey))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalOrderBy(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, False)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
 
-      If entityCount = 1 Then
-        builder.Indent().AppendLine($"Return InternalOrderBy(Of TKey)(keySelector, False)").PopIndent()
-      Else
-        builder.Indent().AppendLine($"Return InternalOrderBy(Of TKey)(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, False)").PopIndent()
-      End If
+    Protected Sub GenerateOrderByDescendingWithPredicateWithOneEntityReturningFormattableString(builder As CodeBuilder, index As Int32, entityCount As Int32)
+      Dim comment = "Adds ORDER BY DESC clause."
+      Dim params = {"keySelector"}
+      AddComment(builder, comment, params:=params, returns:="")
 
+      Dim generic = GetGenericName(index, index = entityCount)
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function OrderByDescending(keySelector As Expression(Of Func(Of {generic}, FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalOrderBy(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, False)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -88,36 +126,33 @@
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
       builder.Indent().AppendLine($"Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of {generics}), TKey))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)").PopIndent()
+      builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, False)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateOrderByDescendingWithPredicateWithIJoinReturningFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds ORDER BY DESC clause."
+      Dim params = {"keySelector"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of {generics}), FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, False)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateInternalOrderBy(builder As CodeBuilder, entityCount As Int32)
-      If entityCount = 1 Then
-        Dim comment = "Adds ORDER BY clause."
-        Dim typeParams = {"TKey"}
-        Dim params = {"keySelector", "ascending"}
-        AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
+      Dim comment = "Adds ORDER BY clause."
+      Dim params = {"keySelector", "entityIndexHints", "ascending"}
+      AddComment(builder, comment, params:=params, returns:="")
 
-        Dim generics = String.Join(", ", GetGenericNames(entityCount))
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-        builder.Indent().AppendLine($"Private Function InternalOrderBy(Of TKey)(keySelector As Expression(Of Func(Of {generics}, TKey)), ascending As Boolean) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
-        builder.Indent().AppendLine("Me.Builder.AddOrderBy(keySelector, {0}, ascending)")
-        builder.Indent().AppendLine($"Return New OrderedSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
-        builder.Indent().AppendLine("End Function")
-      Else
-        Dim comment = "Adds ORDER BY clause."
-        Dim typeParams = {"TKey"}
-        Dim params = {"keySelector", "entityIndexHints", "ascending"}
-        AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
-
-        Dim generics = String.Join(", ", GetGenericNames(entityCount))
-
-        builder.Indent().AppendLine($"Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
-        builder.Indent().AppendLine("Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)")
-        builder.Indent().AppendLine($"Return New OrderedSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
-        builder.Indent().AppendLine("End Function")
-      End If
+      builder.Indent().AppendLine($"Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)")
+      builder.Indent().AppendLine($"Return New OrderedSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
     End Sub
 
   End Class

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.OrderBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.OrderBy.vb
@@ -19,6 +19,9 @@
         builder.AppendLine()
       End If
 
+      GenerateOrderByWithString(builder, entityCount)
+      builder.AppendLine()
+
       For i = 1 To entityCount
         GenerateOrderByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
         builder.AppendLine()
@@ -34,6 +37,9 @@
         GenerateOrderByDescendingWithPredicateWithIJoinReturningFormattableString(builder, entityCount)
         builder.AppendLine()
       End If
+
+      GenerateOrderByDescendingWithString(builder, entityCount)
+      builder.AppendLine()
 
       GenerateInternalOrderBy(builder, entityCount)
     End Sub
@@ -90,6 +96,19 @@
       builder.Indent().AppendLine("End Function")
     End Sub
 
+    Protected Sub GenerateOrderByWithString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds ORDER BY DESC clause."
+      Dim params = {"predicate", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddOrderBy(predicate, True, parameters)")
+      builder.Indent().AppendLine($"Return New OrderedSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
     Protected Sub GenerateOrderByDescendingWithPredicateWithOneEntity(builder As CodeBuilder, index As Int32, entityCount As Int32)
       Dim comment = "Adds ORDER BY DESC clause."
       Dim typeParams = {"TKey"}
@@ -139,6 +158,19 @@
 
       builder.Indent().AppendLine($"Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of {generics}), FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
       builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, False)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateOrderByDescendingWithString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds ORDER BY DESC clause."
+      Dim params = {"predicate", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddOrderBy(predicate, False, parameters)")
+      builder.Indent().AppendLine($"Return New OrderedSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.OrderBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.OrderBy.vb
@@ -3,26 +3,20 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateOrderBy(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
-
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateOrderByWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+      For i = 1 To entityCount
+        GenerateOrderByWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         GenerateOrderByWithPredicateWithIJoin(builder, entityCount)
         builder.AppendLine()
       End If
 
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateOrderByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+      For i = 1 To entityCount
+        GenerateOrderByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         GenerateOrderByDescendingWithPredicateWithIJoin(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Select.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Select.vb
@@ -3,20 +3,16 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateSelect(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
-
       GenerateSelectAll(builder, entityCount)
       builder.AppendLine()
 
       GenerateSelectCount(builder, entityCount)
       builder.AppendLine()
 
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateSelectWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+      For i = 1 To entityCount
+        GenerateSelectWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         If entityCount < 8 Then

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ThenBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ThenBy.vb
@@ -3,26 +3,20 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateThenBy(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
-
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateThenByWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+      For i = 1 To entityCount
+        GenerateThenByWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         GenerateThenByWithPredicateWithIJoin(builder, entityCount)
         builder.AppendLine()
       End If
 
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateThenByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+      For i = 1 To entityCount
+        GenerateThenByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         GenerateThenByDescendingWithPredicateWithIJoin(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ThenBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ThenBy.vb
@@ -6,20 +6,32 @@
       For i = 1 To entityCount
         GenerateThenByWithPredicateWithOneEntity(builder, i, entityCount)
         builder.AppendLine()
+
+        GenerateThenByWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
+        builder.AppendLine()
       Next
 
       If 1 < entityCount Then
         GenerateThenByWithPredicateWithIJoin(builder, entityCount)
+        builder.AppendLine()
+
+        GenerateThenByWithPredicateWithIJoinReturningFormattableString(builder, entityCount)
         builder.AppendLine()
       End If
 
       For i = 1 To entityCount
         GenerateThenByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
         builder.AppendLine()
+
+        GenerateThenByDescendingWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
+        builder.AppendLine()
       Next
 
       If 1 < entityCount Then
         GenerateThenByDescendingWithPredicateWithIJoin(builder, entityCount)
+        builder.AppendLine()
+
+        GenerateThenByDescendingWithPredicateWithIJoinReturningFormattableString(builder, entityCount)
         builder.AppendLine()
       End If
 
@@ -36,13 +48,20 @@
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
       builder.Indent().AppendLine($"Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of {generic}, TKey))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalOrderBy(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, True)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
 
-      If entityCount = 1 Then
-        builder.Indent().AppendLine($"Return InternalOrderBy(Of TKey)(keySelector, True)").PopIndent()
-      Else
-        builder.Indent().AppendLine($"Return InternalOrderBy(Of TKey)(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, True)").PopIndent()
-      End If
+    Protected Sub GenerateThenByWithPredicateWithOneEntityReturningFormattableString(builder As CodeBuilder, index As Int32, entityCount As Int32)
+      Dim comment = "Adds &lt;column&gt; to ORDER BY clause."
+      Dim params = {"keySelector"}
+      AddComment(builder, comment, params:=params, returns:="")
 
+      Dim generic = GetGenericName(index, index = entityCount)
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function ThenBy(keySelector As Expression(Of Func(Of {generic}, FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalOrderBy(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, True)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -55,7 +74,19 @@
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
       builder.Indent().AppendLine($"Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of {generics}), TKey))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)").PopIndent()
+      builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, True)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateThenByWithPredicateWithIJoinReturningFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds &lt;column&gt; to ORDER BY clause."
+      Dim params = {"keySelector"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of {generics}), FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, True)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -69,13 +100,20 @@
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
       builder.Indent().AppendLine($"Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of {generic}, TKey))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalOrderBy(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, False)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
 
-      If entityCount = 1 Then
-        builder.Indent().AppendLine($"Return InternalOrderBy(Of TKey)(keySelector, False)").PopIndent()
-      Else
-        builder.Indent().AppendLine($"Return InternalOrderBy(Of TKey)(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, False)").PopIndent()
-      End If
+    Protected Sub GenerateThenByDescendingWithPredicateWithOneEntityReturningFormattableString(builder As CodeBuilder, index As Int32, entityCount As Int32)
+      Dim comment = "Adds &lt;column&gt; DESC to ORDER BY clause."
+      Dim params = {"keySelector"}
+      AddComment(builder, comment, params:=params, returns:="")
 
+      Dim generic = GetGenericName(index, index = entityCount)
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function ThenByDescending(keySelector As Expression(Of Func(Of {generic}, FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine($"Return InternalOrderBy(keySelector, {GetEntityIndexHintsForEntity(index - 1)}, False)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -88,36 +126,33 @@
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
       builder.Indent().AppendLine($"Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of {generics}), TKey))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)").PopIndent()
+      builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, False)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateThenByDescendingWithPredicateWithIJoinReturningFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds &lt;column&gt; DESC to ORDER BY clause."
+      Dim params = {"keySelector"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of {generics}), FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, False)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
     Protected Sub GenerateInternalOrderByForThenBy(builder As CodeBuilder, entityCount As Int32)
-      If entityCount = 1 Then
-        Dim comment = "Adds ORDER BY clause."
-        Dim typeParams = {"TKey"}
-        Dim params = {"keySelector", "ascending"}
-        AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
+      Dim comment = "Adds ORDER BY clause."
+      Dim params = {"keySelector", "entityIndexHints", "ascending"}
+      AddComment(builder, comment, params:=params, returns:="")
 
-        Dim generics = String.Join(", ", GetGenericNames(entityCount))
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-        builder.Indent().AppendLine($"Private Function InternalOrderBy(Of TKey)(keySelector As Expression(Of Func(Of {generics}, TKey)), ascending As Boolean) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
-        builder.Indent().AppendLine("Me.Builder.AddOrderBy(keySelector, {0}, ascending)")
-        builder.Indent().AppendLine("Return Me").PopIndent()
-        builder.Indent().AppendLine("End Function")
-      Else
-        Dim comment = "Adds ORDER BY clause."
-        Dim typeParams = {"TKey"}
-        Dim params = {"keySelector", "entityIndexHints", "ascending"}
-        AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
-
-        Dim generics = String.Join(", ", GetGenericNames(entityCount))
-
-        builder.Indent().AppendLine($"Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
-        builder.Indent().AppendLine("Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)")
-        builder.Indent().AppendLine("Return Me").PopIndent()
-        builder.Indent().AppendLine("End Function")
-      End If
+      builder.Indent().AppendLine($"Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)")
+      builder.Indent().AppendLine("Return Me").PopIndent()
+      builder.Indent().AppendLine("End Function")
     End Sub
 
   End Class

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ThenBy.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ThenBy.vb
@@ -19,6 +19,9 @@
         builder.AppendLine()
       End If
 
+      GenerateThenByWithString(builder, entityCount)
+      builder.AppendLine()
+
       For i = 1 To entityCount
         GenerateThenByDescendingWithPredicateWithOneEntity(builder, i, entityCount)
         builder.AppendLine()
@@ -34,6 +37,9 @@
         GenerateThenByDescendingWithPredicateWithIJoinReturningFormattableString(builder, entityCount)
         builder.AppendLine()
       End If
+
+      GenerateThenByDescendingWithString(builder, entityCount)
+      builder.AppendLine()
 
       GenerateInternalOrderByForThenBy(builder, entityCount)
     End Sub
@@ -90,6 +96,19 @@
       builder.Indent().AppendLine("End Function")
     End Sub
 
+    Protected Sub GenerateThenByWithString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds &lt;column&gt; to ORDER BY clause."
+      Dim params = {"predicate", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddOrderBy(predicate, True, parameters)")
+      builder.Indent().AppendLine("Return Me").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
     Protected Sub GenerateThenByDescendingWithPredicateWithOneEntity(builder As CodeBuilder, index As Int32, entityCount As Int32)
       Dim comment = "Adds &lt;column&gt; DESC to ORDER BY clause."
       Dim typeParams = {"TKey"}
@@ -139,6 +158,19 @@
 
       builder.Indent().AppendLine($"Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of {generics}), FormattableString))) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
       builder.Indent().AppendLine("Return InternalOrderBy(keySelector, Nothing, False)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateThenByDescendingWithString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds &lt;column&gt; DESC to ORDER BY clause."
+      Dim params = {"predicate", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddOrderBy(predicate, False, parameters)")
+      builder.Indent().AppendLine("Return Me").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.And.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.And.vb
@@ -3,17 +3,13 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateWhereAnd(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
+      For i = 1 To entityCount
+        GenerateWhereAndWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
 
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateWhereAndWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-
-          GenerateWhereAndWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+        GenerateWhereAndWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         If entityCount < 4 Then

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.vb
@@ -3,17 +3,13 @@
   Partial Public Class CodeGenerator
 
     Protected Sub GenerateWhere(builder As CodeBuilder, entityCount As Int32)
-      Dim limit = 8
+      For i = 1 To entityCount
+        GenerateWhereWithPredicateWithOneEntity(builder, i, entityCount)
+        builder.AppendLine()
 
-      If entityCount < limit Then
-        For i = 1 To entityCount
-          GenerateWhereWithPredicateWithOneEntity(builder, i, entityCount)
-          builder.AppendLine()
-
-          GenerateWhereWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
-          builder.AppendLine()
-        Next
-      End If
+        GenerateWhereWithPredicateWithOneEntityReturningFormattableString(builder, i, entityCount)
+        builder.AppendLine()
+      Next
 
       If 1 < entityCount Then
         If entityCount < 4 Then

--- a/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
@@ -534,6 +534,37 @@ Namespace Expressions.Builders
     End Sub
 
     ''' <summary>
+    ''' Adds order by.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="ascending"></param>
+    ''' <param name="parameters"></param>
+    Public Sub AddOrderBy(predicate As String, ascending As Boolean, ParamArray parameters() As Object)
+      If m_OrderByExpressions Is Nothing Then
+        m_OrderByExpressions = New List(Of String)
+      End If
+
+      If parameters Is Nothing OrElse parameters.Length = 0 Then
+        If ascending Then
+          m_OrderByExpressions.Add(predicate)
+        Else
+          m_OrderByExpressions.Add(predicate & " DESC")
+        End If
+      Else
+        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+
+        If ascending Then
+          m_OrderByExpressions.Add(sql.Sql)
+        Else
+          m_OrderByExpressions.Add(sql.Sql & " DESC")
+        End If
+
+        m_Parameters.AddRange(sql.Parameters)
+      End If
+    End Sub
+
+    ''' <summary>
     ''' Adds clause to limit rows returned by the query.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
@@ -104,6 +104,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -118,6 +129,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
       Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
@@ -89,7 +89,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -99,18 +108,27 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
+    ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey)), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
-      Me.Builder.AddOrderBy(keySelector, {0}, ascending)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
@@ -174,7 +174,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -184,7 +193,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -194,7 +212,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -204,7 +231,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -214,7 +250,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -224,18 +269,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
@@ -227,6 +227,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -279,6 +290,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
@@ -203,7 +203,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -213,7 +222,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -223,7 +241,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -233,7 +260,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -243,7 +279,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -253,7 +298,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -263,7 +317,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -273,18 +336,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
@@ -275,6 +275,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -346,6 +357,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
@@ -214,7 +214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -224,7 +233,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -234,7 +252,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -244,7 +271,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -254,7 +290,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -264,7 +309,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -274,7 +328,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -284,7 +347,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -294,7 +366,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -304,18 +385,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
@@ -305,6 +305,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -395,6 +406,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -353,6 +353,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -462,6 +473,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -243,7 +243,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -253,7 +262,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -263,7 +281,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -273,7 +300,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -283,7 +319,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -293,7 +338,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -303,7 +357,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -313,7 +376,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -323,7 +395,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -333,7 +414,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -343,7 +433,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -353,18 +452,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -401,6 +401,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -529,6 +540,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -272,7 +272,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -282,7 +291,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -292,7 +310,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -302,7 +329,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -312,7 +348,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -322,7 +367,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -332,7 +386,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -342,7 +405,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -352,7 +424,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -362,7 +443,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -372,7 +462,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -382,7 +481,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -392,7 +500,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -402,18 +519,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -449,6 +449,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -596,6 +607,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -301,7 +301,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -311,7 +320,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -321,7 +339,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -331,7 +358,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -341,7 +377,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -351,7 +396,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -361,7 +415,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -371,7 +434,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -381,7 +453,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -391,7 +472,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -401,7 +491,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -411,7 +510,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -421,7 +529,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -431,7 +548,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -441,7 +567,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -451,18 +586,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -487,6 +487,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -653,6 +664,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -32,6 +32,150 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -73,6 +217,86 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -95,8 +319,168 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -169,6 +553,86 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -320,7 +320,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -330,7 +339,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -340,7 +358,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -350,7 +377,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -360,7 +396,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -370,7 +415,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -380,7 +434,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -390,7 +453,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -400,7 +472,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -410,7 +491,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -420,7 +510,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -430,7 +529,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -440,7 +548,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -450,7 +567,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -460,7 +586,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -470,7 +605,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -480,7 +624,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -490,18 +643,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -33,6 +33,168 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -74,6 +236,96 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -96,8 +348,188 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -170,6 +602,96 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -349,7 +349,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -359,7 +368,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -369,7 +387,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -379,7 +406,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -389,7 +425,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -399,7 +444,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -409,7 +463,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -419,7 +482,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -429,7 +501,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -439,7 +520,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -449,7 +539,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -459,7 +558,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -469,7 +577,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -479,7 +596,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -489,7 +615,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -499,7 +634,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -509,7 +653,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -519,7 +672,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -529,7 +691,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -539,18 +710,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -535,6 +535,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -720,6 +731,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -583,6 +583,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -787,6 +798,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -34,6 +34,186 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -75,6 +255,106 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -97,8 +377,208 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -171,6 +651,106 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -378,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -388,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -398,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -408,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -418,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -428,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -438,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -448,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -458,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -468,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -478,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -488,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -498,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -508,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -518,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -528,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -538,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -548,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -558,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -568,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -578,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -588,18 +777,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -35,6 +35,204 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -76,6 +274,116 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -98,8 +406,228 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -172,6 +700,116 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -407,7 +407,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -417,7 +426,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -427,7 +445,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -437,7 +464,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -447,7 +483,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -457,7 +502,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -467,7 +521,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -477,7 +540,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -487,7 +559,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -497,7 +578,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -507,7 +597,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -517,7 +616,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -527,7 +635,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -537,7 +654,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -547,7 +673,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -557,7 +692,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -567,7 +711,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -577,7 +730,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -587,7 +749,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -597,7 +768,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -607,7 +787,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -617,7 +806,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -627,7 +825,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -637,18 +844,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -631,6 +631,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -854,6 +865,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -36,6 +36,222 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -77,6 +293,126 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -99,8 +435,248 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -173,6 +749,126 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -679,6 +679,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -921,6 +932,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -436,7 +436,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -446,7 +455,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -456,7 +474,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -466,7 +493,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -476,7 +512,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -486,7 +531,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -496,7 +550,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -506,7 +569,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -516,7 +588,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -526,7 +607,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -536,7 +626,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -546,7 +645,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -556,7 +664,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -566,7 +683,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -576,7 +702,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -586,7 +721,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -596,7 +740,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -606,7 +759,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -616,7 +778,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -626,7 +797,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -636,7 +816,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -646,7 +835,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -656,7 +854,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -666,7 +873,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -676,7 +892,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -686,18 +911,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -727,6 +727,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -988,6 +999,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -465,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -475,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -485,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -495,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -505,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -515,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -525,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -535,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -545,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -555,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -565,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -575,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -585,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -595,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -605,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -615,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -625,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -635,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -645,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -655,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -665,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -675,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -685,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -695,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -705,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -715,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -725,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -735,18 +978,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -37,6 +37,240 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -78,6 +312,136 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -100,8 +464,268 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -174,6 +798,136 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -775,6 +775,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1055,6 +1066,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -494,7 +494,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -504,7 +513,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -514,7 +532,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -524,7 +551,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -534,7 +570,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -544,7 +589,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -554,7 +608,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -564,7 +627,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -574,7 +646,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -584,7 +665,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -594,7 +684,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -604,7 +703,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -614,7 +722,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -624,7 +741,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -634,7 +760,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -644,7 +779,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -654,7 +798,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -664,7 +817,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -674,7 +836,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -684,7 +855,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -694,7 +874,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -704,7 +893,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -714,7 +912,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -724,7 +931,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -734,7 +950,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -744,7 +969,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -754,7 +988,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -764,7 +1007,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -774,7 +1026,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -784,18 +1045,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -38,6 +38,258 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -79,6 +331,146 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -101,8 +493,288 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -175,6 +847,146 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -823,6 +823,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1122,6 +1133,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -523,7 +523,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -533,7 +542,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -543,7 +561,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -553,7 +580,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -563,7 +599,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -573,7 +618,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -583,7 +637,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -593,7 +656,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -603,7 +675,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -613,7 +694,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -623,7 +713,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -633,7 +732,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -643,7 +751,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -653,7 +770,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -663,7 +789,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -673,7 +808,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -683,7 +827,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -693,7 +846,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -703,7 +865,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -713,7 +884,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -723,7 +903,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -733,7 +922,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -743,7 +941,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -753,7 +960,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -763,7 +979,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -773,7 +998,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -783,7 +1017,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -793,7 +1036,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -803,7 +1055,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -813,7 +1074,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -823,7 +1093,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -833,18 +1112,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -39,6 +39,276 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -80,6 +350,156 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -102,8 +522,308 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -176,6 +896,156 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -40,6 +40,294 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -81,6 +369,166 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -103,8 +551,328 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -177,6 +945,166 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -552,7 +552,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -562,7 +571,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -572,7 +590,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -582,7 +609,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -592,7 +628,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -602,7 +647,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -612,7 +666,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -622,7 +685,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -632,7 +704,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -642,7 +723,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -652,7 +742,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -662,7 +761,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -672,7 +780,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -682,7 +799,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -692,7 +818,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -702,7 +837,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -712,7 +856,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -722,7 +875,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -732,7 +894,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -742,7 +913,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -752,7 +932,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -762,7 +951,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -772,7 +970,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -782,7 +989,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -792,7 +1008,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -802,7 +1027,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -812,7 +1046,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -822,7 +1065,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -832,7 +1084,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -842,7 +1103,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -852,7 +1122,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -862,7 +1141,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -872,7 +1160,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -882,18 +1179,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -871,6 +871,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1189,6 +1200,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -919,6 +919,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1256,6 +1267,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -41,6 +41,312 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -82,6 +388,176 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -104,8 +580,348 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -178,6 +994,176 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -581,7 +581,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -591,7 +600,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -601,7 +619,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -611,7 +638,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -621,7 +657,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -631,7 +676,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -641,7 +695,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -651,7 +714,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -661,7 +733,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -671,7 +752,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -681,7 +771,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -691,7 +790,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -701,7 +809,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -711,7 +828,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -721,7 +847,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -731,7 +866,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -741,7 +885,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -751,7 +904,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -761,7 +923,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -771,7 +942,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -781,7 +961,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -791,7 +980,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -801,7 +999,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -811,7 +1018,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -821,7 +1037,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -831,7 +1056,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -841,7 +1075,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -851,7 +1094,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -861,7 +1113,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -871,7 +1132,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -881,7 +1151,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -891,7 +1170,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -901,7 +1189,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -911,7 +1208,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -921,7 +1227,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -931,18 +1246,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -967,6 +967,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1323,6 +1334,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -42,6 +42,330 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -83,6 +407,186 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -105,8 +609,368 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -179,6 +1043,186 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -610,7 +610,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -620,7 +629,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -630,7 +648,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -640,7 +667,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -650,7 +686,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -660,7 +705,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -670,7 +724,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -680,7 +743,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -690,7 +762,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -700,7 +781,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -710,7 +800,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -720,7 +819,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -730,7 +838,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -740,7 +857,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -750,7 +876,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -760,7 +895,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -770,7 +914,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -780,7 +933,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -790,7 +952,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -800,7 +971,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -810,7 +990,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -820,7 +1009,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -830,7 +1028,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -840,7 +1047,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -850,7 +1066,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -860,7 +1085,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -870,7 +1104,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -880,7 +1123,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -890,7 +1142,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -900,7 +1161,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -910,7 +1180,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -920,7 +1199,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -930,7 +1218,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -940,7 +1237,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -950,7 +1256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -960,7 +1275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -970,7 +1294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -980,18 +1313,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -639,7 +639,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -649,7 +658,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -659,7 +677,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -669,7 +696,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -679,7 +715,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -689,7 +734,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -699,7 +753,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -709,7 +772,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -719,7 +791,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -729,7 +810,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -739,7 +829,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -749,7 +848,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -759,7 +867,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -769,7 +886,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -779,7 +905,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -789,7 +924,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -799,7 +943,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -809,7 +962,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -819,7 +981,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -829,7 +1000,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -839,7 +1019,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -849,7 +1038,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -859,7 +1057,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -869,7 +1076,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -879,7 +1095,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -889,7 +1114,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -899,7 +1133,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -909,7 +1152,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -919,7 +1171,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -929,7 +1190,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -939,7 +1209,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -949,7 +1228,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -959,7 +1247,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -969,7 +1266,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -979,7 +1285,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -989,7 +1304,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -999,7 +1323,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1009,7 +1342,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1019,7 +1361,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1029,18 +1380,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -43,6 +43,348 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -84,6 +426,196 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -106,8 +638,388 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -180,6 +1092,196 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1015,6 +1015,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1390,6 +1401,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -668,7 +668,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -678,7 +687,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -688,7 +706,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -698,7 +725,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -708,7 +744,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -718,7 +763,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -728,7 +782,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -738,7 +801,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -748,7 +820,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -758,7 +839,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -768,7 +858,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -778,7 +877,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -788,7 +896,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -798,7 +915,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -808,7 +934,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -818,7 +953,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -828,7 +972,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -838,7 +991,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -848,7 +1010,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -858,7 +1029,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -868,7 +1048,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -878,7 +1067,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -888,7 +1086,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -898,7 +1105,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -908,7 +1124,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -918,7 +1143,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -928,7 +1162,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -938,7 +1181,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -948,7 +1200,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -958,7 +1219,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -968,7 +1238,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -978,7 +1257,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -988,7 +1276,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -998,7 +1295,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1008,7 +1314,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1018,7 +1333,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1028,7 +1352,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1038,7 +1371,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1048,7 +1390,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1058,7 +1409,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1068,7 +1428,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1078,18 +1447,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -44,6 +44,366 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -85,6 +445,206 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -107,8 +667,408 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -181,6 +1141,206 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1063,6 +1063,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1457,6 +1468,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -45,6 +45,384 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -86,6 +464,216 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -108,8 +696,428 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -182,6 +1190,216 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -697,7 +697,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -707,7 +716,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -717,7 +735,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -727,7 +754,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -737,7 +773,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -747,7 +792,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -757,7 +811,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -767,7 +830,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -777,7 +849,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -787,7 +868,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -797,7 +887,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -807,7 +906,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -817,7 +925,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -827,7 +944,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -837,7 +963,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -847,7 +982,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -857,7 +1001,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -867,7 +1020,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -877,7 +1039,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -887,7 +1058,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -897,7 +1077,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -907,7 +1096,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -917,7 +1115,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -927,7 +1134,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -937,7 +1153,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -947,7 +1172,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -957,7 +1191,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -967,7 +1210,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -977,7 +1229,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -987,7 +1248,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -997,7 +1267,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1007,7 +1286,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1017,7 +1305,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1027,7 +1324,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1037,7 +1343,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1047,7 +1362,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1057,7 +1381,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1067,7 +1400,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1077,7 +1419,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1087,7 +1438,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1097,7 +1457,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1107,7 +1476,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1117,7 +1495,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1127,18 +1514,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1111,6 +1111,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1524,6 +1535,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -46,6 +46,402 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -87,6 +483,226 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -109,8 +725,448 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -183,6 +1239,226 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1159,6 +1159,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1591,6 +1602,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -726,7 +726,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -736,7 +745,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -746,7 +764,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -756,7 +783,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -766,7 +802,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -776,7 +821,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -786,7 +840,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -796,7 +859,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -806,7 +878,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -816,7 +897,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -826,7 +916,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -836,7 +935,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -846,7 +954,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -856,7 +973,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -866,7 +992,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -876,7 +1011,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -886,7 +1030,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -896,7 +1049,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -906,7 +1068,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -916,7 +1087,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -926,7 +1106,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -936,7 +1125,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -946,7 +1144,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -956,7 +1163,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -966,7 +1182,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -976,7 +1201,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -986,7 +1220,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -996,7 +1239,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1006,7 +1258,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1016,7 +1277,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1026,7 +1296,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1036,7 +1315,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1046,7 +1334,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1056,7 +1353,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1066,7 +1372,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1076,7 +1391,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1086,7 +1410,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1096,7 +1429,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1106,7 +1448,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1116,7 +1467,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1126,7 +1486,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1136,7 +1505,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1146,7 +1524,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1156,7 +1543,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1166,7 +1562,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1176,18 +1581,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -755,7 +755,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -765,7 +774,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -775,7 +793,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -785,7 +812,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -795,7 +831,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -805,7 +850,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -815,7 +869,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -825,7 +888,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -835,7 +907,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -845,7 +926,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -855,7 +945,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -865,7 +964,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -875,7 +983,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -885,7 +1002,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -895,7 +1021,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -905,7 +1040,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -915,7 +1059,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -925,7 +1078,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -935,7 +1097,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -945,7 +1116,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -955,7 +1135,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -965,7 +1154,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -975,7 +1173,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -985,7 +1192,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -995,7 +1211,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1005,7 +1230,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1015,7 +1249,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1025,7 +1268,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1035,7 +1287,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1045,7 +1306,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1055,7 +1325,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1065,7 +1344,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1075,7 +1363,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1085,7 +1382,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1095,7 +1401,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1105,7 +1420,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1115,7 +1439,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1125,7 +1458,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1135,7 +1477,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1145,7 +1496,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1155,7 +1515,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1165,7 +1534,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1175,7 +1553,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1185,7 +1572,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1195,7 +1591,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1205,7 +1610,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1215,7 +1629,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1225,18 +1648,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -47,6 +47,420 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -88,6 +502,236 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -110,8 +754,468 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -184,6 +1288,236 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1207,6 +1207,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1658,6 +1669,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1255,6 +1255,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1725,6 +1736,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -784,7 +784,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -794,7 +803,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -804,7 +822,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -814,7 +841,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -824,7 +860,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -834,7 +879,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -844,7 +898,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -854,7 +917,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -864,7 +936,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -874,7 +955,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -884,7 +974,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -894,7 +993,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -904,7 +1012,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -914,7 +1031,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -924,7 +1050,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -934,7 +1069,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -944,7 +1088,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -954,7 +1107,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -964,7 +1126,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -974,7 +1145,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -984,7 +1164,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -994,7 +1183,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -1004,7 +1202,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -1014,7 +1221,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -1024,7 +1240,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1034,7 +1259,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1044,7 +1278,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1054,7 +1297,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1064,7 +1316,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1074,7 +1335,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1084,7 +1354,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1094,7 +1373,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1104,7 +1392,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1114,7 +1411,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1124,7 +1430,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1134,7 +1449,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1144,7 +1468,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1154,7 +1487,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1164,7 +1506,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1174,7 +1525,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1184,7 +1544,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1194,7 +1563,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1204,7 +1582,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1214,7 +1601,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1224,7 +1620,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1234,7 +1639,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1244,7 +1658,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1254,7 +1677,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1264,7 +1696,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -1274,18 +1715,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -48,6 +48,438 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T24, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T24, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -89,6 +521,246 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -111,8 +783,488 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -185,6 +1337,246 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -813,7 +813,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -823,7 +832,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -833,7 +851,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -843,7 +870,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -853,7 +889,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -863,7 +908,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -873,7 +927,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -883,7 +946,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -893,7 +965,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -903,7 +984,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -913,7 +1003,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -923,7 +1022,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -933,7 +1041,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -943,7 +1060,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -953,7 +1079,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -963,7 +1098,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -973,7 +1117,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -983,7 +1136,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -993,7 +1155,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -1003,7 +1174,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -1013,7 +1193,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -1023,7 +1212,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -1033,7 +1231,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -1043,7 +1250,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -1053,7 +1269,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+      Return InternalOrderBy(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, True)
     End Function
 
     ''' <summary>
@@ -1063,7 +1288,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1073,7 +1307,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1083,7 +1326,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1093,7 +1345,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1103,7 +1364,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1113,7 +1383,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1123,7 +1402,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1133,7 +1421,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1143,7 +1440,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1153,7 +1459,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1163,7 +1478,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1173,7 +1497,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1183,7 +1516,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1193,7 +1535,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1203,7 +1554,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1213,7 +1573,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1223,7 +1592,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1233,7 +1611,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1243,7 +1630,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1253,7 +1649,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1263,7 +1668,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1273,7 +1687,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1283,7 +1706,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1293,7 +1725,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1303,7 +1744,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -1313,7 +1763,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
+      Return InternalOrderBy(keySelector, {24}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -1323,18 +1782,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -49,6 +49,456 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T24, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T24, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T25, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T25, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -90,6 +540,256 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -112,8 +812,508 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -186,6 +1386,256 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1303,6 +1303,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1792,6 +1803,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
@@ -75,7 +75,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -85,18 +94,27 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
+    ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey)), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
-      Me.Builder.AddOrderBy(keySelector, {0}, ascending)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
@@ -90,6 +90,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -104,6 +115,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
       Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
@@ -183,6 +183,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -235,6 +246,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
@@ -130,7 +130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -140,7 +149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -150,7 +168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -160,7 +187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -170,7 +206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -180,18 +225,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
@@ -149,7 +149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -159,7 +168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -169,7 +187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -179,7 +206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -189,7 +225,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -199,7 +244,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -209,7 +263,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -219,18 +282,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
@@ -221,6 +221,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -292,6 +303,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
@@ -150,7 +150,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -160,7 +169,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -170,7 +188,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -180,7 +207,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -190,7 +226,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -200,7 +245,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -210,7 +264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -220,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -230,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -240,18 +321,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
@@ -241,6 +241,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -331,6 +342,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -279,6 +279,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -388,6 +399,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -169,7 +169,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -179,7 +188,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -189,7 +207,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -199,7 +226,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -209,7 +245,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -219,7 +264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -229,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -239,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -249,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -259,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -269,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -279,18 +378,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -317,6 +317,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -445,6 +456,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -188,7 +188,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -198,7 +207,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -208,7 +226,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -218,7 +245,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -228,7 +264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -238,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -248,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -258,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -268,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -278,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -288,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -298,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -308,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -318,18 +435,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -355,6 +355,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -502,6 +513,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -207,7 +207,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -217,7 +226,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -227,7 +245,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -237,7 +264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -247,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -257,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -267,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -277,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -287,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -297,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -307,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -317,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -327,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -337,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -347,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -357,18 +492,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -32,6 +32,150 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -81,8 +225,168 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -155,6 +459,86 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -393,6 +393,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -559,6 +570,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -226,7 +226,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -236,7 +245,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -246,7 +264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -256,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -266,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -276,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -286,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -296,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -306,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -316,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -326,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -336,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -346,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -356,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -366,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -376,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -386,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -396,18 +549,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -245,7 +245,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -255,7 +264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -265,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -275,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -285,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -295,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -305,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -315,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -325,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -335,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -345,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -355,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -365,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -375,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -385,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -395,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -405,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -415,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -425,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -435,18 +606,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -33,6 +33,168 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -82,8 +244,188 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -156,6 +498,96 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -431,6 +431,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -616,6 +627,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -264,7 +264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -274,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -284,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -294,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -304,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -314,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -324,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -334,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -344,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -354,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -364,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -374,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -384,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -394,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -404,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -414,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -424,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -434,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -444,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -454,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -464,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -474,18 +663,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -469,6 +469,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -673,6 +684,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -34,6 +34,186 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -83,8 +263,208 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -157,6 +537,106 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -35,6 +35,204 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -84,8 +282,228 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -158,6 +576,116 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -507,6 +507,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -730,6 +741,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -283,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -293,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -303,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -313,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -323,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -333,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -343,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -353,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -363,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -373,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -383,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -393,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -403,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -413,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -423,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -433,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -443,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -453,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -463,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -473,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -483,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -493,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -503,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -513,18 +720,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -36,6 +36,222 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -85,8 +301,248 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -159,6 +615,126 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -302,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -312,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -322,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -332,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -342,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -352,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -362,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -372,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -382,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -392,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -402,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -412,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -422,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -432,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -442,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -452,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -462,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -472,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -482,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -492,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -502,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -512,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -522,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -532,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -542,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -552,18 +777,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -545,6 +545,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -787,6 +798,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -321,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -331,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -341,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -351,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -361,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -371,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -381,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -391,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -401,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -411,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -421,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -431,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -441,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -451,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -461,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -471,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -481,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -491,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -501,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -511,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -521,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -531,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -541,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -551,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -561,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -571,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -581,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -591,18 +834,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -583,6 +583,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -844,6 +855,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -37,6 +37,240 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -86,8 +320,268 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -160,6 +654,136 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -38,6 +38,258 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -87,8 +339,288 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -161,6 +693,146 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -340,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -350,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -360,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -370,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -380,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -390,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -400,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -410,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -420,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -430,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -440,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -450,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -460,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -470,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -480,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -490,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -500,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -510,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -520,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -530,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -540,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -550,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -560,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -570,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -580,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -590,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -600,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -610,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -620,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -630,18 +891,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -621,6 +621,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -901,6 +912,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -659,6 +659,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -958,6 +969,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -359,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -369,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -379,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -389,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -399,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -409,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -419,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -429,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -439,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -449,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -459,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -469,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -479,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -489,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -499,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -509,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -519,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -529,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -539,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -549,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -559,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -569,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -579,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -589,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -599,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -609,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -619,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -629,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -639,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -649,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -659,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -669,18 +948,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -39,6 +39,276 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -88,8 +358,308 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -162,6 +732,156 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -378,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -388,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -398,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -408,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -418,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -428,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -438,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -448,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -458,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -468,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -478,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -488,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -498,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -508,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -518,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -528,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -538,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -548,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -558,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -568,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -578,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -588,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -598,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -608,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -618,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -628,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -638,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -648,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -658,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -668,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -678,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -688,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -698,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -708,18 +1005,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -697,6 +697,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1015,6 +1026,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -40,6 +40,294 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -89,8 +377,328 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -163,6 +771,166 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -397,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -407,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -417,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -427,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -437,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -447,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -457,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -467,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -477,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -487,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -497,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -507,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -517,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -527,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -537,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -547,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -557,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -567,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -577,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -587,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -597,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -607,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -617,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -627,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -637,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -647,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -657,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -667,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -677,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -687,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -697,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -707,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -717,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -727,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -737,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -747,18 +1062,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -735,6 +735,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1072,6 +1083,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -41,6 +41,312 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -90,8 +396,348 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -164,6 +810,176 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -773,6 +773,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1129,6 +1140,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -42,6 +42,330 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -91,8 +415,368 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -165,6 +849,186 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -416,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -426,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -436,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -446,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -456,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -466,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -476,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -486,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -496,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -506,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -516,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -526,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -536,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -546,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -556,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -566,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -576,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -586,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -596,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -606,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -616,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -626,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -636,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -646,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -656,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -666,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -676,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -686,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -696,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -706,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -716,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -726,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -736,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -746,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -756,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -766,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -776,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -786,18 +1119,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -43,6 +43,348 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -92,8 +434,388 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -166,6 +888,196 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -435,7 +435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -445,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -455,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -465,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -475,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -485,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -495,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -505,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -515,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -525,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -535,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -545,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -555,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -565,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -575,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -585,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -595,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -605,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -615,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -625,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -635,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -645,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -655,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -665,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -675,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -685,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -695,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -705,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -715,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -725,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -735,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -745,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -755,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -765,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -775,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -785,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -795,7 +1119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -805,7 +1138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -815,7 +1157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -825,18 +1176,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -811,6 +811,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1186,6 +1197,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -44,6 +44,366 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -93,8 +453,408 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -167,6 +927,206 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -454,7 +454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -464,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -474,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -484,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -494,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -504,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -514,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -524,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -534,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -544,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -554,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -564,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -574,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -584,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -594,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -604,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -614,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -624,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -634,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -644,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -654,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -664,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -674,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -684,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -694,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -704,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -714,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -724,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -734,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -744,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -754,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -764,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -774,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -784,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -794,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -804,7 +1119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -814,7 +1138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -824,7 +1157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -834,7 +1176,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -844,7 +1195,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -854,7 +1214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -864,18 +1233,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -849,6 +849,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1243,6 +1254,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -887,6 +887,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1300,6 +1311,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -473,7 +473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -483,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -493,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -503,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -513,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -523,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -533,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -543,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -553,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -563,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -573,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -583,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -593,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -603,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -613,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -623,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -633,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -643,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -653,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -663,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -673,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -683,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -693,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -703,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -713,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -723,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -733,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -743,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -753,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -763,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -773,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -783,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -793,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -803,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -813,7 +1119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -823,7 +1138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -833,7 +1157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -843,7 +1176,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -853,7 +1195,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -863,7 +1214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -873,7 +1233,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -883,7 +1252,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -893,7 +1271,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -903,18 +1290,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -45,6 +45,384 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -94,8 +472,428 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -168,6 +966,216 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -925,6 +925,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1357,6 +1368,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -46,6 +46,402 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T22, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T22, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -95,8 +491,448 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -169,6 +1005,226 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -492,7 +492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -502,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -512,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -522,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -532,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -542,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -552,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -562,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -572,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -582,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -592,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -602,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -612,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -622,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -632,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -642,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -652,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -662,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -672,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -682,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -692,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -702,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -712,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -722,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -732,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -742,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -752,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -762,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -772,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -782,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -792,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -802,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -812,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -822,7 +1119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -832,7 +1138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -842,7 +1157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -852,7 +1176,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -862,7 +1195,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -872,7 +1214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -882,7 +1233,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -892,7 +1252,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -902,7 +1271,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -912,7 +1290,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -922,7 +1309,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -932,7 +1328,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -942,18 +1347,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -963,6 +963,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1414,6 +1425,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -47,6 +47,420 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T22, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T22, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T23, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T23, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -96,8 +510,468 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -170,6 +1044,236 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -511,7 +511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -521,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -531,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -541,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -551,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -561,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -571,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -581,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -591,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -601,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -611,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -621,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -631,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -641,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -651,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -661,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -671,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -681,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -691,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -701,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -711,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -721,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -731,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -741,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -751,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -761,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -771,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -781,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -791,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -801,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -811,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -821,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -831,7 +1119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -841,7 +1138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -851,7 +1157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -861,7 +1176,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -871,7 +1195,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -881,7 +1214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -891,7 +1233,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -901,7 +1252,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -911,7 +1271,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -921,7 +1290,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -931,7 +1309,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -941,7 +1328,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -951,7 +1347,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -961,7 +1366,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -971,7 +1385,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -981,18 +1404,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1001,6 +1001,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1471,6 +1482,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -530,7 +530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -540,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -550,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -560,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -570,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -580,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -590,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -600,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -610,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -620,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -630,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -640,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -650,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -660,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -670,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -680,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -690,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -700,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -710,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -720,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -730,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -740,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -750,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -760,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -770,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -780,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -790,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -800,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -810,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -820,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -830,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -840,7 +1119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -850,7 +1138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -860,7 +1157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -870,7 +1176,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -880,7 +1195,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -890,7 +1214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -900,7 +1233,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -910,7 +1252,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -920,7 +1271,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -930,7 +1290,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -940,7 +1309,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -950,7 +1328,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -960,7 +1347,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -970,7 +1366,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -980,7 +1385,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -990,7 +1404,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1000,7 +1423,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1010,7 +1442,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -1020,18 +1461,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -48,6 +48,438 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T22, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T22, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T23, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T23, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T24, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T24, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -97,8 +529,488 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -171,6 +1083,246 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -49,6 +49,456 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T22, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T22, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T23, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T23, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T24, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T24, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T25, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Having(predicate As Expression(Of Func(Of T25, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Having(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -98,8 +548,508 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -172,6 +1122,256 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -549,7 +549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -559,7 +568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -569,7 +587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -579,7 +606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -589,7 +625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -599,7 +644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -609,7 +663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -619,7 +682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -629,7 +701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -639,7 +720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -649,7 +739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -659,7 +758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -669,7 +777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -679,7 +796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -689,7 +815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -699,7 +834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -709,7 +853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -719,7 +872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -729,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -739,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -749,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -759,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -769,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -779,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -789,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+      Return InternalOrderBy(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, True)
     End Function
 
     ''' <summary>
@@ -799,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -809,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -819,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -829,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -839,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -849,7 +1119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -859,7 +1138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -869,7 +1157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -879,7 +1176,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -889,7 +1195,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -899,7 +1214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -909,7 +1233,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -919,7 +1252,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -929,7 +1271,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -939,7 +1290,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -949,7 +1309,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -959,7 +1328,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -969,7 +1347,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -979,7 +1366,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -989,7 +1385,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -999,7 +1404,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1009,7 +1423,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1019,7 +1442,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1029,7 +1461,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1039,7 +1480,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -1049,7 +1499,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
+      Return InternalOrderBy(keySelector, {24}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -1059,18 +1518,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1039,6 +1039,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1528,6 +1539,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
@@ -82,6 +82,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -96,6 +107,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
       Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
@@ -67,7 +67,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -77,18 +86,27 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
+    ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey)), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
-      Me.Builder.AddOrderBy(keySelector, {0}, ascending)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
@@ -122,7 +122,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -132,7 +141,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -142,7 +160,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -152,7 +179,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -162,7 +198,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -172,18 +217,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
@@ -175,6 +175,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -227,6 +238,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
@@ -213,6 +213,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -284,6 +295,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
@@ -141,7 +141,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -151,7 +160,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -161,7 +179,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -171,7 +198,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -181,7 +217,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -191,7 +236,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -201,7 +255,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -211,18 +274,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
@@ -233,6 +233,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -323,6 +334,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
@@ -142,7 +142,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -152,7 +161,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -162,7 +180,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -172,7 +199,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -182,7 +218,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -192,7 +237,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -202,7 +256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -212,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -222,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -232,18 +313,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -161,7 +161,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -171,7 +180,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -181,7 +199,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -191,7 +218,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -201,7 +237,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -211,7 +256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -221,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -231,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -241,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -251,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -261,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -271,18 +370,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -271,6 +271,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -380,6 +391,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -309,6 +309,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -437,6 +448,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -180,7 +180,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -190,7 +199,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -200,7 +218,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -210,7 +237,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -220,7 +256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -230,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -240,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -250,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -260,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -270,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -280,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -290,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -300,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -310,18 +427,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -347,6 +347,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -494,6 +505,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -199,7 +199,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -209,7 +218,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -219,7 +237,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -229,7 +256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -239,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -249,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -259,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -269,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -279,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -289,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -299,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -309,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -319,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -329,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -339,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -349,18 +484,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -32,6 +32,150 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -73,8 +217,168 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -147,6 +451,86 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -218,7 +218,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -228,7 +237,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -238,7 +256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -248,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -258,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -268,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -278,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -288,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -298,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -308,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -318,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -328,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -338,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -348,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -358,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -368,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -378,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -388,18 +541,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -385,6 +385,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -551,6 +562,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -423,6 +423,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -608,6 +619,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -33,6 +33,168 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -74,8 +236,188 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -148,6 +490,96 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -237,7 +237,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -247,7 +256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -257,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -267,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -277,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -287,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -297,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -307,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -317,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -327,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -337,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -347,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -357,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -367,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -377,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -387,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -397,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -407,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -417,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -427,18 +598,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -34,6 +34,186 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -75,8 +255,208 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -149,6 +529,106 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -461,6 +461,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -665,6 +676,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -256,7 +256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -266,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -276,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -286,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -296,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -306,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -316,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -326,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -336,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -346,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -356,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -366,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -376,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -386,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -396,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -406,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -416,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -426,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -436,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -446,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -456,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -466,18 +655,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -275,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -285,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -295,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -305,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -315,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -325,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -335,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -345,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -355,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -365,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -375,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -385,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -395,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -405,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -415,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -425,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -435,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -445,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -455,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -465,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -475,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -485,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -495,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -505,18 +712,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -35,6 +35,204 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -76,8 +274,228 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -150,6 +568,116 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -499,6 +499,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -722,6 +733,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -294,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -304,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -314,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -324,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -334,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -344,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -354,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -364,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -374,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -384,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -394,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -404,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -414,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -424,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -434,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -444,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -454,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -464,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -474,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -484,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -494,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -504,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -514,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -524,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -534,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -544,18 +769,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -537,6 +537,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -779,6 +790,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -36,6 +36,222 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -77,8 +293,248 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -151,6 +607,126 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -313,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -323,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -333,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -343,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -353,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -363,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -373,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -383,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -393,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -403,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -413,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -423,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -433,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -443,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -453,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -463,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -473,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -483,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -493,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -503,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -513,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -523,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -533,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -543,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -553,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -563,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -573,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -583,18 +826,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -575,6 +575,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -836,6 +847,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -37,6 +37,240 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -78,8 +312,268 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -152,6 +646,136 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -38,6 +38,258 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -79,8 +331,288 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -153,6 +685,146 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -613,6 +613,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -893,6 +904,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -332,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -342,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -352,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -362,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -372,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -382,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -392,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -402,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -412,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -422,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -432,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -442,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -452,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -462,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -472,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -482,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -492,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -502,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -512,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -522,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -532,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -542,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -552,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -562,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -572,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -582,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -592,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -602,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -612,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -622,18 +883,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -351,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -361,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -371,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -381,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -391,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -401,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -411,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -421,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -431,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -441,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -451,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -461,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -471,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -481,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -491,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -501,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -511,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -521,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -531,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -541,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -551,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -561,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -571,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -581,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -591,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -601,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -611,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -621,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -631,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -641,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -651,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -661,18 +940,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -651,6 +651,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -950,6 +961,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -39,6 +39,276 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -80,8 +350,308 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -154,6 +724,156 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -370,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -380,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -390,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -400,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -410,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -420,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -430,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -440,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -450,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -460,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -470,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -480,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -490,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -500,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -510,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -520,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -530,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -540,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -550,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -560,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -570,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -580,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -590,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -600,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -610,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -620,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -630,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -640,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -650,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -660,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -670,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -680,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -690,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -700,18 +997,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -40,6 +40,294 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -81,8 +369,328 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -155,6 +763,166 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -689,6 +689,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1007,6 +1018,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -727,6 +727,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1064,6 +1075,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -389,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -399,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -409,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -419,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -429,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -439,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -449,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -459,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -469,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -479,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -489,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -499,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -509,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -519,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -529,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -539,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -549,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -559,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -569,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -579,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -589,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -599,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -609,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -619,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -629,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -639,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -649,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -659,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -669,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -679,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -689,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -699,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -709,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -719,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -729,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -739,18 +1054,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -41,6 +41,312 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -82,8 +388,348 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -156,6 +802,176 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -408,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -418,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -428,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -438,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -448,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -458,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -468,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -478,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -488,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -498,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -508,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -518,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -528,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -538,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -548,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -558,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -568,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -578,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -588,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -598,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -608,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -618,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -628,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -638,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -648,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -658,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -668,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -678,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -688,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -698,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -708,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -718,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -728,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -738,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -748,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -758,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -768,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -778,18 +1111,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -765,6 +765,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1121,6 +1132,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -42,6 +42,330 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -83,8 +407,368 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -157,6 +841,186 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -803,6 +803,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1178,6 +1189,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -427,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -437,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -447,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -457,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -467,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -477,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -487,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -497,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -507,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -517,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -527,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -537,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -547,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -557,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -567,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -577,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -587,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -597,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -607,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -617,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -627,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -637,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -647,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -657,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -667,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -677,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -687,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -697,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -707,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -717,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -727,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -737,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -747,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -757,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -767,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -777,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -787,7 +1111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -797,7 +1130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -807,7 +1149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -817,18 +1168,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -43,6 +43,348 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -84,8 +426,388 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -158,6 +880,196 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -841,6 +841,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1235,6 +1246,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -446,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -456,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -466,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -476,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -486,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -496,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -506,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -516,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -526,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -536,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -546,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -556,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -566,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -576,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -586,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -596,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -606,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -616,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -626,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -636,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -646,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -656,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -666,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -676,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -686,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -696,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -706,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -716,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -726,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -736,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -746,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -756,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -766,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -776,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -786,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -796,7 +1111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -806,7 +1130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -816,7 +1149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -826,7 +1168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -836,7 +1187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -846,7 +1206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -856,18 +1225,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -44,6 +44,366 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -85,8 +445,408 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -159,6 +919,206 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -465,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -475,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -485,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -495,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -505,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -515,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -525,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -535,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -545,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -555,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -565,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -575,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -585,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -595,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -605,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -615,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -625,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -635,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -645,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -655,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -665,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -675,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -685,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -695,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -705,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -715,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -725,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -735,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -745,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -755,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -765,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -775,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -785,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -795,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -805,7 +1111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -815,7 +1130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -825,7 +1149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -835,7 +1168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -845,7 +1187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -855,7 +1206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -865,7 +1225,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -875,7 +1244,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -885,7 +1263,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -895,18 +1282,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -879,6 +879,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1292,6 +1303,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -45,6 +45,384 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -86,8 +464,428 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -160,6 +958,216 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -46,6 +46,402 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -87,8 +483,448 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -161,6 +997,226 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -484,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -494,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -504,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -514,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -524,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -534,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -544,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -554,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -564,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -574,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -584,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -594,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -604,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -614,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -624,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -634,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -644,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -654,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -664,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -674,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -684,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -694,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -704,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -714,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -724,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -734,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -744,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -754,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -764,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -774,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -784,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -794,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -804,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -814,7 +1111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -824,7 +1130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -834,7 +1149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -844,7 +1168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -854,7 +1187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -864,7 +1206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -874,7 +1225,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -884,7 +1244,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -894,7 +1263,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -904,7 +1282,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -914,7 +1301,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -924,7 +1320,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -934,18 +1339,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -917,6 +917,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1349,6 +1360,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -955,6 +955,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1406,6 +1417,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -503,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -513,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -523,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -533,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -543,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -553,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -563,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -573,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -583,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -593,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -603,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -613,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -623,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -633,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -643,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -653,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -663,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -673,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -683,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -693,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -703,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -713,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -723,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -733,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -743,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -753,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -763,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -773,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -783,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -793,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -803,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -813,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -823,7 +1111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -833,7 +1130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -843,7 +1149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -853,7 +1168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -863,7 +1187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -873,7 +1206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -883,7 +1225,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -893,7 +1244,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -903,7 +1263,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -913,7 +1282,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -923,7 +1301,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -933,7 +1320,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -943,7 +1339,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -953,7 +1358,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -963,7 +1377,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -973,18 +1396,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -47,6 +47,420 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -88,8 +502,468 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -162,6 +1036,236 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -522,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -532,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -542,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -552,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -562,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -572,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -582,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -592,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -602,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -612,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -622,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -632,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -642,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -652,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -662,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -672,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -682,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -692,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -702,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -712,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -722,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -732,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -742,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -752,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -762,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -772,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -782,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -792,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -802,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -812,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -822,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -832,7 +1111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -842,7 +1130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -852,7 +1149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -862,7 +1168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -872,7 +1187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -882,7 +1206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -892,7 +1225,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -902,7 +1244,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -912,7 +1263,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -922,7 +1282,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -932,7 +1301,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -942,7 +1320,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -952,7 +1339,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -962,7 +1358,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -972,7 +1377,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -982,7 +1396,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -992,7 +1415,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1002,7 +1434,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -1012,18 +1453,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -48,6 +48,438 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T24, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T24, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalHaving(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -89,8 +521,488 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -163,6 +1075,246 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -993,6 +993,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1463,6 +1474,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -49,6 +49,456 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T1, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T2, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T3, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T4, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T5, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T6, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T7, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T8, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T9, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T10, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T11, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T12, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T13, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T14, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T15, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T16, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T17, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T18, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T19, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T20, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T21, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T22, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T23, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T24, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T24, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T25, Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function [And](predicate As Expression(Of Func(Of T25, FormattableString))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalHaving(predicate, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds AND condition to HAVING clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function [And](predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), Boolean))) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalHaving(predicate, Nothing)
     End Function
@@ -90,8 +540,508 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -164,6 +1114,256 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -541,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -551,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -561,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -571,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -581,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -591,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -601,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -611,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -621,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -631,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -641,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -651,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -661,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -671,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -681,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -691,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -701,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -711,7 +864,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -721,7 +883,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -731,7 +902,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -741,7 +921,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -751,7 +940,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -761,7 +959,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -771,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -781,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+      Return InternalOrderBy(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, True)
     End Function
 
     ''' <summary>
@@ -791,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -801,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -811,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -821,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -831,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -841,7 +1111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -851,7 +1130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -861,7 +1149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -871,7 +1168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -881,7 +1187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -891,7 +1206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -901,7 +1225,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -911,7 +1244,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -921,7 +1263,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -931,7 +1282,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -941,7 +1301,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -951,7 +1320,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -961,7 +1339,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -971,7 +1358,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -981,7 +1377,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -991,7 +1396,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1001,7 +1415,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1011,7 +1434,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1021,7 +1453,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1031,7 +1472,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -1041,7 +1491,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
+      Return InternalOrderBy(keySelector, {24}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -1051,18 +1510,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1031,6 +1031,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1520,6 +1531,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -33,6 +33,76 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -34,6 +34,86 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -35,6 +35,96 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -36,6 +36,106 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -37,6 +37,116 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -38,6 +38,126 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -39,6 +39,136 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -40,6 +40,146 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -41,6 +41,156 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -42,6 +42,166 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -43,6 +43,176 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T17, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -44,6 +44,186 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T17, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T18, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -45,6 +45,196 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T17, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T18, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T19, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -46,6 +46,206 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T17, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T18, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T19, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T20, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -47,6 +47,216 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T17, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T18, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T19, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T20, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T21, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -48,6 +48,226 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T17, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T18, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T19, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T20, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T21, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T22, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -49,6 +49,236 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T17, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T18, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T19, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T20, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T21, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T22, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T23, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/JoinedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -50,6 +50,246 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T1, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T2, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T3, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T4, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T5, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T6, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T7, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T8, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T9, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T10, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T11, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T12, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T13, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T14, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T15, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T16, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T17, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T18, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T19, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T20, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T21, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T22, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T23, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
+    Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of T24, TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalAs(relationship)
+    End Function
+
+    ''' <summary>
+    ''' Specifies last joined entity.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="relationship"></param>
+    ''' <returns></returns>
     Public Function [As](Of TProperty)(relationship As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TProperty))) As SelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalAs(relationship)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -52,6 +52,86 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -53,6 +53,96 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -54,6 +54,106 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -55,6 +55,116 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -56,6 +56,126 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -57,6 +57,136 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -58,6 +58,146 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -59,6 +59,156 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -60,6 +60,166 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -61,6 +61,176 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -62,6 +62,186 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -63,6 +63,196 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -64,6 +64,206 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -65,6 +65,216 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -66,6 +66,226 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -67,6 +67,236 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -68,6 +68,246 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -69,6 +69,256 @@ Namespace Expressions
     ''' <typeparam name="TResult"></typeparam>
     ''' <param name="selector"></param>
     ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
     Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TResult))) As CustomSelectSqlExpression(Of TResult)
       Return InternalSelect(Of TResult)(selector, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
@@ -40,6 +40,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -56,6 +67,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
       Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
@@ -27,7 +27,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -37,18 +46,27 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
+    ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey)), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
-      Me.Builder.AddOrderBy(keySelector, {0}, ascending)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
@@ -28,7 +28,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -38,7 +47,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -48,7 +66,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -58,7 +85,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -68,7 +104,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -78,18 +123,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
@@ -79,6 +79,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -133,6 +144,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
@@ -99,6 +99,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -172,6 +183,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
@@ -29,7 +29,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -39,7 +48,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -49,7 +67,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -59,7 +86,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -69,7 +105,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -79,7 +124,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -89,7 +143,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -99,18 +162,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
@@ -119,6 +119,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -211,6 +222,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
@@ -30,7 +30,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -40,7 +49,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -50,7 +68,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -60,7 +87,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -70,7 +106,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -80,7 +125,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -90,7 +144,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -100,7 +163,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -110,7 +182,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -120,18 +201,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -31,7 +31,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -41,7 +50,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -51,7 +69,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -61,7 +88,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -71,7 +107,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -81,7 +126,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -91,7 +145,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -101,7 +164,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -111,7 +183,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -121,7 +202,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -131,7 +221,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -141,18 +240,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -139,6 +139,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -250,6 +261,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -159,6 +159,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -289,6 +300,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -32,7 +32,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -42,7 +51,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -52,7 +70,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -62,7 +89,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -72,7 +108,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -82,7 +127,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -92,7 +146,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -102,7 +165,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -112,7 +184,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -122,7 +203,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -132,7 +222,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -142,7 +241,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -152,7 +260,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -162,18 +279,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -33,7 +33,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -43,7 +52,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -53,7 +71,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -63,7 +90,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -73,7 +109,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -83,7 +128,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -93,7 +147,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -103,7 +166,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -113,7 +185,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -123,7 +204,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -133,7 +223,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -143,7 +242,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -153,7 +261,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -163,7 +280,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -173,7 +299,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -183,18 +318,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -179,6 +179,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -328,6 +339,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -199,6 +199,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -367,6 +378,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -34,7 +34,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -44,7 +53,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -54,7 +72,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -64,7 +91,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -74,7 +110,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -84,7 +129,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -94,7 +148,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -104,7 +167,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -114,7 +186,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -124,7 +205,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -134,7 +224,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -144,7 +243,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -154,7 +262,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -164,7 +281,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -174,7 +300,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -184,7 +319,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -194,7 +338,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -204,18 +357,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -33,8 +33,168 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -107,6 +267,86 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -34,8 +34,188 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -108,6 +288,96 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -219,6 +219,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -406,6 +417,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -35,7 +35,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -45,7 +54,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -55,7 +73,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -65,7 +92,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -75,7 +111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -85,7 +130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -95,7 +149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -105,7 +168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -115,7 +187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -125,7 +206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -135,7 +225,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -145,7 +244,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -155,7 +263,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -165,7 +282,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -175,7 +301,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -185,7 +320,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -195,7 +339,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -205,7 +358,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -215,7 +377,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -225,18 +396,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -239,6 +239,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -445,6 +456,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -35,8 +35,208 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -109,6 +309,106 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -36,7 +36,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -46,7 +55,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -56,7 +74,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -66,7 +93,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -76,7 +112,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -86,7 +131,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -96,7 +150,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -106,7 +169,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -116,7 +188,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -126,7 +207,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -136,7 +226,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -146,7 +245,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -156,7 +264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -166,7 +283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -176,7 +302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -186,7 +321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -196,7 +340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -206,7 +359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -216,7 +378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -226,7 +397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -236,7 +416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -246,18 +435,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -37,7 +37,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -47,7 +56,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -57,7 +75,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -67,7 +94,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -77,7 +113,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -87,7 +132,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -97,7 +151,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -107,7 +170,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -117,7 +189,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -127,7 +208,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -137,7 +227,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -147,7 +246,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -157,7 +265,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -167,7 +284,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -177,7 +303,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -187,7 +322,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -197,7 +341,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -207,7 +360,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -217,7 +379,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -227,7 +398,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -237,7 +417,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -247,7 +436,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -257,7 +455,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -267,18 +474,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -259,6 +259,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -484,6 +495,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -36,8 +36,228 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -110,6 +330,116 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -38,7 +38,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -48,7 +57,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -58,7 +76,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -68,7 +95,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -78,7 +114,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -88,7 +133,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -98,7 +152,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -108,7 +171,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -118,7 +190,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -128,7 +209,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -138,7 +228,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -148,7 +247,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -158,7 +266,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -168,7 +285,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -178,7 +304,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -188,7 +323,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -198,7 +342,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -208,7 +361,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -218,7 +380,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -228,7 +399,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -238,7 +418,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -248,7 +437,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -258,7 +456,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -268,7 +475,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -278,7 +494,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -288,18 +513,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -37,8 +37,248 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -111,6 +351,126 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -279,6 +279,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -523,6 +534,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -38,8 +38,268 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -112,6 +372,136 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -39,7 +39,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -49,7 +58,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -59,7 +77,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -69,7 +96,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -79,7 +115,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -89,7 +134,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -99,7 +153,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -109,7 +172,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -119,7 +191,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -129,7 +210,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -139,7 +229,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -149,7 +248,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -159,7 +267,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -169,7 +286,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -179,7 +305,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -189,7 +324,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -199,7 +343,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -209,7 +362,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -219,7 +381,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -229,7 +400,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -239,7 +419,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -249,7 +438,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -259,7 +457,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -269,7 +476,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -279,7 +495,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -289,7 +514,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -299,7 +533,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -309,18 +552,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -299,6 +299,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -562,6 +573,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -40,7 +40,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -50,7 +59,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -60,7 +78,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -70,7 +97,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -80,7 +116,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -90,7 +135,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -100,7 +154,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -110,7 +173,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -120,7 +192,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -130,7 +211,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -140,7 +230,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -150,7 +249,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -160,7 +268,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -170,7 +287,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -180,7 +306,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -190,7 +325,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -200,7 +344,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -210,7 +363,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -220,7 +382,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -230,7 +401,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -240,7 +420,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -250,7 +439,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -260,7 +458,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -270,7 +477,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -280,7 +496,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -290,7 +515,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -300,7 +534,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -310,7 +553,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -320,7 +572,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -330,18 +591,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -319,6 +319,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -601,6 +612,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -39,8 +39,288 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -113,6 +393,146 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -41,7 +41,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -51,7 +60,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -61,7 +79,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -71,7 +98,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -81,7 +117,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -91,7 +136,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -101,7 +155,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -111,7 +174,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -121,7 +193,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -131,7 +212,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -141,7 +231,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -151,7 +250,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -161,7 +269,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -171,7 +288,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -181,7 +307,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -191,7 +326,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -201,7 +345,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -211,7 +364,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -221,7 +383,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -231,7 +402,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -241,7 +421,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -251,7 +440,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -261,7 +459,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -271,7 +478,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -281,7 +497,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -291,7 +516,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -301,7 +535,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -311,7 +554,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -321,7 +573,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -331,7 +592,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -341,7 +611,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -351,18 +630,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -339,6 +339,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -640,6 +651,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -40,8 +40,308 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -114,6 +414,156 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -359,6 +359,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -679,6 +690,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -41,8 +41,328 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -115,6 +435,166 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -42,7 +42,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -52,7 +61,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -62,7 +80,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -72,7 +99,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -82,7 +118,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -92,7 +137,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -102,7 +156,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -112,7 +175,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -122,7 +194,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -132,7 +213,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -142,7 +232,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -152,7 +251,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -162,7 +270,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -172,7 +289,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -182,7 +308,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -192,7 +327,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -202,7 +346,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -212,7 +365,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -222,7 +384,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -232,7 +403,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -242,7 +422,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -252,7 +441,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -262,7 +460,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -272,7 +479,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -282,7 +498,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -292,7 +517,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -302,7 +536,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -312,7 +555,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -322,7 +574,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -332,7 +593,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -342,7 +612,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -352,7 +631,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -362,7 +650,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -372,18 +669,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -379,6 +379,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -718,6 +729,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -43,7 +43,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -53,7 +62,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -63,7 +81,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -73,7 +100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -83,7 +119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -93,7 +138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -103,7 +157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -113,7 +176,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -123,7 +195,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -133,7 +214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -143,7 +233,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -153,7 +252,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -163,7 +271,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -173,7 +290,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -183,7 +309,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -193,7 +328,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -203,7 +347,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -213,7 +366,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -223,7 +385,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -233,7 +404,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -243,7 +423,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -253,7 +442,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -263,7 +461,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -273,7 +480,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -283,7 +499,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -293,7 +518,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -303,7 +537,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -313,7 +556,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -323,7 +575,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -333,7 +594,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -343,7 +613,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -353,7 +632,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -363,7 +651,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -373,7 +670,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -383,7 +689,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -393,18 +708,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -42,8 +42,348 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -116,6 +456,176 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -44,7 +44,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -54,7 +63,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -64,7 +82,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -74,7 +101,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -84,7 +120,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -94,7 +139,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -104,7 +158,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -114,7 +177,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -124,7 +196,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -134,7 +215,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -144,7 +234,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -154,7 +253,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -164,7 +272,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -174,7 +291,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -184,7 +310,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -194,7 +329,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -204,7 +348,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -214,7 +367,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -224,7 +386,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -234,7 +405,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -244,7 +424,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -254,7 +443,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -264,7 +462,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -274,7 +481,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -284,7 +500,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -294,7 +519,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -304,7 +538,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -314,7 +557,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -324,7 +576,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -334,7 +595,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -344,7 +614,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -354,7 +633,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -364,7 +652,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -374,7 +671,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -384,7 +690,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -394,7 +709,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -404,7 +728,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -414,18 +747,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -43,8 +43,368 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -117,6 +477,186 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -399,6 +399,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -757,6 +768,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -45,7 +45,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -55,7 +64,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -65,7 +83,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -75,7 +102,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -85,7 +121,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -95,7 +140,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -105,7 +159,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -115,7 +178,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -125,7 +197,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -135,7 +216,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -145,7 +235,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -155,7 +254,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -165,7 +273,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -175,7 +292,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -185,7 +311,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -195,7 +330,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -205,7 +349,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -215,7 +368,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -225,7 +387,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -235,7 +406,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -245,7 +425,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -255,7 +444,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -265,7 +463,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -275,7 +482,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -285,7 +501,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -295,7 +520,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -305,7 +539,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -315,7 +558,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -325,7 +577,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -335,7 +596,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -345,7 +615,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -355,7 +634,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -365,7 +653,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -375,7 +672,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -385,7 +691,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -395,7 +710,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -405,7 +729,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -415,7 +748,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -425,7 +767,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -435,18 +786,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -44,8 +44,388 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -118,6 +498,196 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -419,6 +419,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -796,6 +807,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -45,8 +45,408 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -119,6 +519,206 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -46,7 +46,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -56,7 +65,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -66,7 +84,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -76,7 +103,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -86,7 +122,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -96,7 +141,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -106,7 +160,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -116,7 +179,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -126,7 +198,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -136,7 +217,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -146,7 +236,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -156,7 +255,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -166,7 +274,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -176,7 +293,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -186,7 +312,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -196,7 +331,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -206,7 +350,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -216,7 +369,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -226,7 +388,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -236,7 +407,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -246,7 +426,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -256,7 +445,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -266,7 +464,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -276,7 +483,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -286,7 +502,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -296,7 +521,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -306,7 +540,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -316,7 +559,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -326,7 +578,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -336,7 +597,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -346,7 +616,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -356,7 +635,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -366,7 +654,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -376,7 +673,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -386,7 +692,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -396,7 +711,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -406,7 +730,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -416,7 +749,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -426,7 +768,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -436,7 +787,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -446,7 +806,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -456,18 +825,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -439,6 +439,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -835,6 +846,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -459,6 +459,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -874,6 +885,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -47,7 +47,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -57,7 +66,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -67,7 +85,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -77,7 +104,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -87,7 +123,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -97,7 +142,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -107,7 +161,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -117,7 +180,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -127,7 +199,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -137,7 +218,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -147,7 +237,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -157,7 +256,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -167,7 +275,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -177,7 +294,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -187,7 +313,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -197,7 +332,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -207,7 +351,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -217,7 +370,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -227,7 +389,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -237,7 +408,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -247,7 +427,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -257,7 +446,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -267,7 +465,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -277,7 +484,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -287,7 +503,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -297,7 +522,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -307,7 +541,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -317,7 +560,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -327,7 +579,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -337,7 +598,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -347,7 +617,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -357,7 +636,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -367,7 +655,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -377,7 +674,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -387,7 +693,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -397,7 +712,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -407,7 +731,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -417,7 +750,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -427,7 +769,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -437,7 +788,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -447,7 +807,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -457,7 +826,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -467,7 +845,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -477,18 +864,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -46,8 +46,428 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -120,6 +540,216 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -48,7 +48,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -58,7 +67,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -68,7 +86,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -78,7 +105,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -88,7 +124,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -98,7 +143,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -108,7 +162,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -118,7 +181,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -128,7 +200,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -138,7 +219,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -148,7 +238,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -158,7 +257,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -168,7 +276,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -178,7 +295,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -188,7 +314,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -198,7 +333,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -208,7 +352,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -218,7 +371,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -228,7 +390,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -238,7 +409,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -248,7 +428,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -258,7 +447,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -268,7 +466,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -278,7 +485,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -288,7 +504,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -298,7 +523,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -308,7 +542,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -318,7 +561,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -328,7 +580,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -338,7 +599,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -348,7 +618,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -358,7 +637,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -368,7 +656,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -378,7 +675,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -388,7 +694,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -398,7 +713,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -408,7 +732,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -418,7 +751,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -428,7 +770,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -438,7 +789,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -448,7 +808,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -458,7 +827,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -468,7 +846,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -478,7 +865,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -488,7 +884,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -498,18 +903,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -47,8 +47,448 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -121,6 +561,226 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -479,6 +479,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -913,6 +924,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -48,8 +48,468 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -122,6 +582,236 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -49,7 +49,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -59,7 +68,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -69,7 +87,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -79,7 +106,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -89,7 +125,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -99,7 +144,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -109,7 +163,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -119,7 +182,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -129,7 +201,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -139,7 +220,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -149,7 +239,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -159,7 +258,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -169,7 +277,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -179,7 +296,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -189,7 +315,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -199,7 +334,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -209,7 +353,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -219,7 +372,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -229,7 +391,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -239,7 +410,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -249,7 +429,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -259,7 +448,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -269,7 +467,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -279,7 +486,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -289,7 +505,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -299,7 +524,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -309,7 +543,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -319,7 +562,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -329,7 +581,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -339,7 +600,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -349,7 +619,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -359,7 +638,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -369,7 +657,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -379,7 +676,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -389,7 +695,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -399,7 +714,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -409,7 +733,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -419,7 +752,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -429,7 +771,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -439,7 +790,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -449,7 +809,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -459,7 +828,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -469,7 +847,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -479,7 +866,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -489,7 +885,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -499,7 +904,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -509,7 +923,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -519,18 +942,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -499,6 +499,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -952,6 +963,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -50,7 +50,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -60,7 +69,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -70,7 +88,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -80,7 +107,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -90,7 +126,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -100,7 +145,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -110,7 +164,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -120,7 +183,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -130,7 +202,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -140,7 +221,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -150,7 +240,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -160,7 +259,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -170,7 +278,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -180,7 +297,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -190,7 +316,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -200,7 +335,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -210,7 +354,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -220,7 +373,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -230,7 +392,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -240,7 +411,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -250,7 +430,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -260,7 +449,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -270,7 +468,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -280,7 +487,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -290,7 +506,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -300,7 +525,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -310,7 +544,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -320,7 +563,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -330,7 +582,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -340,7 +601,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -350,7 +620,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -360,7 +639,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -370,7 +658,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -380,7 +677,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -390,7 +696,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -400,7 +715,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -410,7 +734,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -420,7 +753,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -430,7 +772,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -440,7 +791,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -450,7 +810,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -460,7 +829,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -470,7 +848,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -480,7 +867,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -490,7 +886,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -500,7 +905,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -510,7 +924,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -520,7 +943,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -530,7 +962,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -540,18 +981,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -49,8 +49,488 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -123,6 +603,246 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -519,6 +519,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -991,6 +1002,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -539,6 +539,17 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return Me
+    End Function
+
+    ''' <summary>
     ''' Adds &lt;column&gt; DESC to ORDER BY clause.
     ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
@@ -1030,6 +1041,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return Me
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -51,7 +51,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -61,7 +70,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -71,7 +89,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -81,7 +108,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -91,7 +127,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -101,7 +146,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -111,7 +165,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -121,7 +184,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -131,7 +203,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -141,7 +222,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -151,7 +241,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -161,7 +260,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -171,7 +279,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -181,7 +298,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -191,7 +317,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -201,7 +336,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -211,7 +355,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -221,7 +374,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -231,7 +393,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -241,7 +412,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -251,7 +431,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -261,7 +450,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -271,7 +469,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -281,7 +488,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -291,7 +507,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+      Return InternalOrderBy(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, True)
     End Function
 
     ''' <summary>
@@ -301,7 +526,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -311,7 +545,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -321,7 +564,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -331,7 +583,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -341,7 +602,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -351,7 +621,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -361,7 +640,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -371,7 +659,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -381,7 +678,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -391,7 +697,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -401,7 +716,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -411,7 +735,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -421,7 +754,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -431,7 +773,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -441,7 +792,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -451,7 +811,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -461,7 +830,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -471,7 +849,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -481,7 +868,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -491,7 +887,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -501,7 +906,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -511,7 +925,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -521,7 +944,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -531,7 +963,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -541,7 +982,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -551,7 +1001,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
+      Return InternalOrderBy(keySelector, {24}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -561,18 +1020,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return Me
     End Function

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -50,8 +50,508 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function ThenBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds &lt;column&gt; DESC to ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function ThenByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -124,6 +624,256 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -426,6 +426,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -440,6 +451,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
       Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -411,7 +411,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -421,18 +430,27 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
+    ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey)), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
-      Me.Builder.AddOrderBy(keySelector, {0}, ascending)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
@@ -599,6 +599,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -651,6 +662,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
@@ -546,7 +546,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -556,7 +565,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -566,7 +584,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -576,7 +603,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -586,7 +622,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -596,18 +641,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2), TKey))) As OrderedSelectSqlExpression(Of T1, T2)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
@@ -647,6 +647,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -718,6 +729,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
@@ -575,7 +575,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -585,7 +594,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -595,7 +613,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -605,7 +632,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -615,7 +651,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -625,7 +670,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -635,7 +689,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -645,18 +708,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
@@ -626,7 +626,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -636,7 +645,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -646,7 +664,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -656,7 +683,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -666,7 +702,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -676,7 +721,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -686,7 +740,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -696,7 +759,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -706,7 +778,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -716,18 +797,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
@@ -717,6 +717,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -807,6 +818,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
@@ -805,6 +805,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -914,6 +925,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
@@ -695,7 +695,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -705,7 +714,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -715,7 +733,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -725,7 +752,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -735,7 +771,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -745,7 +790,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -755,7 +809,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -765,7 +828,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -775,7 +847,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -785,7 +866,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -795,7 +885,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -805,18 +904,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -893,6 +893,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1021,6 +1032,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -764,7 +764,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -774,7 +783,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -784,7 +802,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -794,7 +821,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -804,7 +840,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -814,7 +859,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -824,7 +878,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -834,7 +897,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -844,7 +916,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -854,7 +935,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -864,7 +954,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -874,7 +973,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -884,7 +992,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -894,18 +1011,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -701,6 +701,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -848,6 +859,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -553,7 +553,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -563,7 +572,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -573,7 +591,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -583,7 +610,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -593,7 +629,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -603,7 +648,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -613,7 +667,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -623,7 +686,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -633,7 +705,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -643,7 +724,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -653,7 +743,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -663,7 +762,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -673,7 +781,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -683,7 +800,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -693,7 +819,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -703,18 +838,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -276,6 +276,150 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -325,6 +469,86 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -347,8 +571,168 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -421,6 +805,86 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -739,6 +739,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -905,6 +916,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -572,7 +572,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -582,7 +591,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -592,7 +610,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -602,7 +629,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -612,7 +648,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -622,7 +667,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -632,7 +686,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -642,7 +705,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -652,7 +724,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -662,7 +743,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -672,7 +762,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -682,7 +781,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -692,7 +800,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -702,7 +819,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -712,7 +838,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -722,7 +857,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -732,7 +876,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -742,18 +895,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -277,6 +277,168 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -326,6 +488,96 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -348,8 +600,188 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -422,6 +854,96 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -601,7 +601,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -611,7 +620,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -621,7 +639,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -631,7 +658,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -641,7 +677,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -651,7 +696,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -661,7 +715,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -671,7 +734,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -681,7 +753,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -691,7 +772,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -701,7 +791,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -711,7 +810,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -721,7 +829,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -731,7 +848,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -741,7 +867,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -751,7 +886,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -761,7 +905,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -771,7 +924,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -781,7 +943,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -791,18 +962,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -787,6 +787,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -972,6 +983,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -835,6 +835,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1039,6 +1050,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -278,6 +278,186 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -327,6 +507,106 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -349,8 +629,208 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -423,6 +903,106 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -630,7 +630,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -640,7 +649,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -650,7 +668,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -660,7 +687,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -670,7 +706,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -680,7 +725,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -690,7 +744,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -700,7 +763,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -710,7 +782,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -720,7 +801,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -730,7 +820,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -740,7 +839,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -750,7 +858,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -760,7 +877,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -770,7 +896,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -780,7 +915,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -790,7 +934,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -800,7 +953,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -810,7 +972,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -820,7 +991,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -830,7 +1010,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -840,18 +1029,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -279,6 +279,204 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -328,6 +526,116 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -350,8 +658,228 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -424,6 +952,116 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -659,7 +659,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -669,7 +678,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -679,7 +697,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -689,7 +716,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -699,7 +735,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -709,7 +754,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -719,7 +773,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -729,7 +792,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -739,7 +811,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -749,7 +830,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -759,7 +849,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -769,7 +868,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -779,7 +887,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -789,7 +906,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -799,7 +925,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -809,7 +944,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -819,7 +963,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -829,7 +982,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -839,7 +1001,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -849,7 +1020,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -859,7 +1039,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -869,7 +1058,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -879,7 +1077,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -889,18 +1096,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -883,6 +883,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1106,6 +1117,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -280,6 +280,222 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -329,6 +545,126 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -351,8 +687,248 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -425,6 +1001,126 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -931,6 +931,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1173,6 +1184,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -688,7 +688,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -698,7 +707,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -708,7 +726,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -718,7 +745,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -728,7 +764,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -738,7 +783,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -748,7 +802,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -758,7 +821,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -768,7 +840,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -778,7 +859,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -788,7 +878,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -798,7 +897,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -808,7 +916,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -818,7 +935,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -828,7 +954,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -838,7 +973,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -848,7 +992,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -858,7 +1011,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -868,7 +1030,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -878,7 +1049,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -888,7 +1068,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -898,7 +1087,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -908,7 +1106,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -918,7 +1125,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -928,7 +1144,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -938,18 +1163,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -717,7 +717,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -727,7 +736,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -737,7 +755,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -747,7 +774,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -757,7 +793,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -767,7 +812,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -777,7 +831,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -787,7 +850,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -797,7 +869,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -807,7 +888,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -817,7 +907,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -827,7 +926,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -837,7 +945,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -847,7 +964,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -857,7 +983,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -867,7 +1002,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -877,7 +1021,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -887,7 +1040,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -897,7 +1059,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -907,7 +1078,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -917,7 +1097,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -927,7 +1116,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -937,7 +1135,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -947,7 +1154,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -957,7 +1173,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -967,7 +1192,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -977,7 +1211,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -987,18 +1230,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -979,6 +979,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1240,6 +1251,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -281,6 +281,240 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -330,6 +564,136 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -352,8 +716,268 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -426,6 +1050,136 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -1027,6 +1027,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1307,6 +1318,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -746,7 +746,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -756,7 +765,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -766,7 +784,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -776,7 +803,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -786,7 +822,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -796,7 +841,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -806,7 +860,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -816,7 +879,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -826,7 +898,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -836,7 +917,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -846,7 +936,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -856,7 +955,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -866,7 +974,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -876,7 +993,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -886,7 +1012,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -896,7 +1031,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -906,7 +1050,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -916,7 +1069,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -926,7 +1088,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -936,7 +1107,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -946,7 +1126,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -956,7 +1145,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -966,7 +1164,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -976,7 +1183,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -986,7 +1202,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -996,7 +1221,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1006,7 +1240,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1016,7 +1259,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1026,7 +1278,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1036,18 +1297,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -282,6 +282,258 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -331,6 +583,146 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -353,8 +745,288 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -427,6 +1099,146 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -775,7 +775,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -785,7 +794,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -795,7 +813,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -805,7 +832,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -815,7 +851,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -825,7 +870,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -835,7 +889,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -845,7 +908,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -855,7 +927,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -865,7 +946,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -875,7 +965,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -885,7 +984,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -895,7 +1003,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -905,7 +1022,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -915,7 +1041,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -925,7 +1060,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -935,7 +1079,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -945,7 +1098,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -955,7 +1117,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -965,7 +1136,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -975,7 +1155,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -985,7 +1174,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -995,7 +1193,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1005,7 +1212,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1015,7 +1231,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1025,7 +1250,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1035,7 +1269,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1045,7 +1288,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1055,7 +1307,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1065,7 +1326,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1075,7 +1345,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1085,18 +1364,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -283,6 +283,276 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -332,6 +602,156 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -354,8 +774,308 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -428,6 +1148,156 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1075,6 +1075,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1374,6 +1385,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -284,6 +284,294 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -333,6 +621,166 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -355,8 +803,328 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -429,6 +1197,166 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -804,7 +804,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -814,7 +823,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -824,7 +842,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -834,7 +861,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -844,7 +880,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -854,7 +899,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -864,7 +918,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -874,7 +937,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -884,7 +956,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -894,7 +975,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -904,7 +994,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -914,7 +1013,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -924,7 +1032,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -934,7 +1051,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -944,7 +1070,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -954,7 +1089,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -964,7 +1108,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -974,7 +1127,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -984,7 +1146,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -994,7 +1165,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1004,7 +1184,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1014,7 +1203,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1024,7 +1222,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1034,7 +1241,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1044,7 +1260,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1054,7 +1279,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1064,7 +1298,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1074,7 +1317,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1084,7 +1336,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1094,7 +1355,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1104,7 +1374,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1114,7 +1393,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1124,7 +1412,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1134,18 +1431,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -1123,6 +1123,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1441,6 +1452,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -1171,6 +1171,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1508,6 +1519,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -285,6 +285,312 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -334,6 +640,176 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -356,8 +832,348 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -430,6 +1246,176 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -833,7 +833,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -843,7 +852,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -853,7 +871,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -863,7 +890,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -873,7 +909,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -883,7 +928,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -893,7 +947,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -903,7 +966,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -913,7 +985,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -923,7 +1004,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -933,7 +1023,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -943,7 +1042,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -953,7 +1061,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -963,7 +1080,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -973,7 +1099,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -983,7 +1118,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -993,7 +1137,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -1003,7 +1156,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1013,7 +1175,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1023,7 +1194,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1033,7 +1213,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1043,7 +1232,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1053,7 +1251,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1063,7 +1270,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1073,7 +1289,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1083,7 +1308,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1093,7 +1327,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1103,7 +1346,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1113,7 +1365,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1123,7 +1384,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1133,7 +1403,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1143,7 +1422,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1153,7 +1441,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1163,7 +1460,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1173,7 +1479,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1183,18 +1498,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -862,7 +862,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -872,7 +881,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -882,7 +900,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -892,7 +919,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -902,7 +938,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -912,7 +957,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -922,7 +976,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -932,7 +995,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -942,7 +1014,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -952,7 +1033,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -962,7 +1052,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -972,7 +1071,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -982,7 +1090,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -992,7 +1109,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -1002,7 +1128,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -1012,7 +1147,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -1022,7 +1166,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -1032,7 +1185,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -1042,7 +1204,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1052,7 +1223,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1062,7 +1242,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1072,7 +1261,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1082,7 +1280,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1092,7 +1299,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1102,7 +1318,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1112,7 +1337,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1122,7 +1356,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1132,7 +1375,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1142,7 +1394,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1152,7 +1413,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1162,7 +1432,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1172,7 +1451,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1182,7 +1470,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1192,7 +1489,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1202,7 +1508,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1212,7 +1527,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1222,7 +1546,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1232,18 +1565,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -286,6 +286,330 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -335,6 +659,186 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -357,8 +861,368 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -431,6 +1295,186 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -1219,6 +1219,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1575,6 +1586,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -287,6 +287,348 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -336,6 +678,196 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -358,8 +890,388 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -432,6 +1344,196 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -891,7 +891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -901,7 +910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -911,7 +929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -921,7 +948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -931,7 +967,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -941,7 +986,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -951,7 +1005,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -961,7 +1024,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -971,7 +1043,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -981,7 +1062,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -991,7 +1081,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -1001,7 +1100,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -1011,7 +1119,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -1021,7 +1138,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -1031,7 +1157,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -1041,7 +1176,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -1051,7 +1195,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -1061,7 +1214,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -1071,7 +1233,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -1081,7 +1252,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1091,7 +1271,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1101,7 +1290,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1111,7 +1309,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1121,7 +1328,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1131,7 +1347,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1141,7 +1366,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1151,7 +1385,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1161,7 +1404,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1171,7 +1423,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1181,7 +1442,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1191,7 +1461,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1201,7 +1480,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1211,7 +1499,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1221,7 +1518,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1231,7 +1537,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1241,7 +1556,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1251,7 +1575,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1261,7 +1594,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1271,7 +1613,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1281,18 +1632,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1267,6 +1267,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1642,6 +1653,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -920,7 +920,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -930,7 +939,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -940,7 +958,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -950,7 +977,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -960,7 +996,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -970,7 +1015,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -980,7 +1034,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -990,7 +1053,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -1000,7 +1072,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -1010,7 +1091,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -1020,7 +1110,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -1030,7 +1129,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -1040,7 +1148,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -1050,7 +1167,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -1060,7 +1186,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -1070,7 +1205,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -1080,7 +1224,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -1090,7 +1243,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -1100,7 +1262,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -1110,7 +1281,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -1120,7 +1300,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1130,7 +1319,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1140,7 +1338,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1150,7 +1357,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1160,7 +1376,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1170,7 +1395,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1180,7 +1414,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1190,7 +1433,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1200,7 +1452,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1210,7 +1471,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1220,7 +1490,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1230,7 +1509,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1240,7 +1528,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1250,7 +1547,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1260,7 +1566,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1270,7 +1585,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1280,7 +1604,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1290,7 +1623,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1300,7 +1642,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1310,7 +1661,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1320,7 +1680,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1330,18 +1699,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1315,6 +1315,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1709,6 +1720,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -288,6 +288,366 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -337,6 +697,206 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -359,8 +919,408 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -433,6 +1393,206 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -949,7 +949,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -959,7 +968,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -969,7 +987,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -979,7 +1006,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -989,7 +1025,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -999,7 +1044,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -1009,7 +1063,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -1019,7 +1082,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -1029,7 +1101,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -1039,7 +1120,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -1049,7 +1139,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -1059,7 +1158,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -1069,7 +1177,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -1079,7 +1196,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -1089,7 +1215,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -1099,7 +1234,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -1109,7 +1253,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -1119,7 +1272,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -1129,7 +1291,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -1139,7 +1310,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -1149,7 +1329,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -1159,7 +1348,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1169,7 +1367,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1179,7 +1386,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1189,7 +1405,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1199,7 +1424,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1209,7 +1443,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1219,7 +1462,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1229,7 +1481,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1239,7 +1500,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1249,7 +1519,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1259,7 +1538,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1269,7 +1557,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1279,7 +1576,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1289,7 +1595,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1299,7 +1614,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1309,7 +1633,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1319,7 +1652,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1329,7 +1671,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1339,7 +1690,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1349,7 +1709,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1359,7 +1728,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1369,7 +1747,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1379,18 +1766,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1363,6 +1363,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1776,6 +1787,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -289,6 +289,384 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -338,6 +716,216 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -360,8 +948,428 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -434,6 +1442,216 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -290,6 +290,402 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T22, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T22, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -339,6 +735,226 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalGroupBy(Of TKey)(keySelector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -361,8 +977,448 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -435,6 +1491,226 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -978,7 +978,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -988,7 +997,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -998,7 +1016,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -1008,7 +1035,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -1018,7 +1054,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -1028,7 +1073,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -1038,7 +1092,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -1048,7 +1111,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -1058,7 +1130,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -1068,7 +1149,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -1078,7 +1168,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -1088,7 +1187,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -1098,7 +1206,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -1108,7 +1225,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -1118,7 +1244,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -1128,7 +1263,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -1138,7 +1282,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -1148,7 +1301,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -1158,7 +1320,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -1168,7 +1339,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -1178,7 +1358,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -1188,7 +1377,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -1198,7 +1396,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1208,7 +1415,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1218,7 +1434,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1228,7 +1453,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1238,7 +1472,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1248,7 +1491,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1258,7 +1510,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1268,7 +1529,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1278,7 +1548,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1288,7 +1567,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1298,7 +1586,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1308,7 +1605,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1318,7 +1624,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1328,7 +1643,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1338,7 +1662,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1348,7 +1681,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1358,7 +1700,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1368,7 +1719,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1378,7 +1738,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1388,7 +1757,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1398,7 +1776,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1408,7 +1795,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1418,7 +1814,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1428,18 +1833,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1411,6 +1411,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1843,6 +1854,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1459,6 +1459,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1910,6 +1921,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1007,7 +1007,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -1017,7 +1026,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -1027,7 +1045,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -1037,7 +1064,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -1047,7 +1083,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -1057,7 +1102,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -1067,7 +1121,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -1077,7 +1140,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -1087,7 +1159,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -1097,7 +1178,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -1107,7 +1197,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -1117,7 +1216,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -1127,7 +1235,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -1137,7 +1254,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -1147,7 +1273,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -1157,7 +1292,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -1167,7 +1311,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -1177,7 +1330,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -1187,7 +1349,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -1197,7 +1368,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -1207,7 +1387,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -1217,7 +1406,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -1227,7 +1425,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -1237,7 +1444,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1247,7 +1463,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1257,7 +1482,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1267,7 +1501,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1277,7 +1520,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1287,7 +1539,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1297,7 +1558,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1307,7 +1577,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1317,7 +1596,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1327,7 +1615,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1337,7 +1634,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1347,7 +1653,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1357,7 +1672,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1367,7 +1691,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1377,7 +1710,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1387,7 +1729,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1397,7 +1748,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1407,7 +1767,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1417,7 +1786,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1427,7 +1805,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1437,7 +1824,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1447,7 +1843,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1457,7 +1862,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1467,7 +1881,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1477,18 +1900,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -291,6 +291,420 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T22, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T22, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T23, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T23, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -340,6 +754,236 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalGroupBy(Of TKey)(keySelector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -362,8 +1006,468 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -436,6 +1540,236 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1036,7 +1036,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -1046,7 +1055,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -1056,7 +1074,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -1066,7 +1093,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -1076,7 +1112,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -1086,7 +1131,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -1096,7 +1150,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -1106,7 +1169,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -1116,7 +1188,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -1126,7 +1207,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -1136,7 +1226,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -1146,7 +1245,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -1156,7 +1264,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -1166,7 +1283,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -1176,7 +1302,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -1186,7 +1321,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -1196,7 +1340,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -1206,7 +1359,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -1216,7 +1378,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -1226,7 +1397,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -1236,7 +1416,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -1246,7 +1435,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -1256,7 +1454,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -1266,7 +1473,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -1276,7 +1492,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1286,7 +1511,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1296,7 +1530,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1306,7 +1549,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1316,7 +1568,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1326,7 +1587,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1336,7 +1606,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1346,7 +1625,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1356,7 +1644,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1366,7 +1663,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1376,7 +1682,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1386,7 +1701,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1396,7 +1720,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1406,7 +1739,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1416,7 +1758,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1426,7 +1777,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1436,7 +1796,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1446,7 +1815,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1456,7 +1834,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1466,7 +1853,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1476,7 +1872,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1486,7 +1891,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1496,7 +1910,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1506,7 +1929,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1516,7 +1948,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -1526,18 +1967,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -292,6 +292,438 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T22, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T22, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T23, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T23, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T24, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T24, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalWhere(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -341,6 +773,246 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalGroupBy(Of TKey)(keySelector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -363,8 +1035,488 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -437,6 +1589,246 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1507,6 +1507,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1977,6 +1988,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1312,6 +1312,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -1801,6 +1812,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -822,7 +822,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -832,7 +841,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+      Return InternalOrderBy(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, True)
     End Function
 
     ''' <summary>
@@ -842,7 +860,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+      Return InternalOrderBy(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, True)
     End Function
 
     ''' <summary>
@@ -852,7 +879,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+      Return InternalOrderBy(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, True)
     End Function
 
     ''' <summary>
@@ -862,7 +898,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+      Return InternalOrderBy(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, True)
     End Function
 
     ''' <summary>
@@ -872,7 +917,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+      Return InternalOrderBy(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, True)
     End Function
 
     ''' <summary>
@@ -882,7 +936,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+      Return InternalOrderBy(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, True)
     End Function
 
     ''' <summary>
@@ -892,7 +955,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+      Return InternalOrderBy(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, True)
     End Function
 
     ''' <summary>
@@ -902,7 +974,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+      Return InternalOrderBy(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, True)
     End Function
 
     ''' <summary>
@@ -912,7 +993,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+      Return InternalOrderBy(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, True)
     End Function
 
     ''' <summary>
@@ -922,7 +1012,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+      Return InternalOrderBy(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, True)
     End Function
 
     ''' <summary>
@@ -932,7 +1031,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+      Return InternalOrderBy(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, True)
     End Function
 
     ''' <summary>
@@ -942,7 +1050,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+      Return InternalOrderBy(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, True)
     End Function
 
     ''' <summary>
@@ -952,7 +1069,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+      Return InternalOrderBy(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, True)
     End Function
 
     ''' <summary>
@@ -962,7 +1088,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+      Return InternalOrderBy(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, True)
     End Function
 
     ''' <summary>
@@ -972,7 +1107,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+      Return InternalOrderBy(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, True)
     End Function
 
     ''' <summary>
@@ -982,7 +1126,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+      Return InternalOrderBy(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, True)
     End Function
 
     ''' <summary>
@@ -992,7 +1145,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+      Return InternalOrderBy(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, True)
     End Function
 
     ''' <summary>
@@ -1002,7 +1164,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+      Return InternalOrderBy(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, True)
     End Function
 
     ''' <summary>
@@ -1012,7 +1183,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+      Return InternalOrderBy(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, True)
     End Function
 
     ''' <summary>
@@ -1022,7 +1202,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+      Return InternalOrderBy(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, True)
     End Function
 
     ''' <summary>
@@ -1032,7 +1221,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+      Return InternalOrderBy(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, True)
     End Function
 
     ''' <summary>
@@ -1042,7 +1240,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+      Return InternalOrderBy(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, True)
     End Function
 
     ''' <summary>
@@ -1052,7 +1259,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+      Return InternalOrderBy(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, True)
     End Function
 
     ''' <summary>
@@ -1062,7 +1278,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+      Return InternalOrderBy(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, True)
     End Function
 
     ''' <summary>
@@ -1072,7 +1297,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+      Return InternalOrderBy(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, True)
     End Function
 
     ''' <summary>
@@ -1082,7 +1316,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T1, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
@@ -1092,7 +1335,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+      Return InternalOrderBy(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T2, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {1}, False)
     End Function
 
     ''' <summary>
@@ -1102,7 +1354,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+      Return InternalOrderBy(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T3, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {2}, False)
     End Function
 
     ''' <summary>
@@ -1112,7 +1373,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+      Return InternalOrderBy(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T4, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {3}, False)
     End Function
 
     ''' <summary>
@@ -1122,7 +1392,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+      Return InternalOrderBy(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T5, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {4}, False)
     End Function
 
     ''' <summary>
@@ -1132,7 +1411,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+      Return InternalOrderBy(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T6, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {5}, False)
     End Function
 
     ''' <summary>
@@ -1142,7 +1430,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+      Return InternalOrderBy(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T7, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {6}, False)
     End Function
 
     ''' <summary>
@@ -1152,7 +1449,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+      Return InternalOrderBy(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T8, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {7}, False)
     End Function
 
     ''' <summary>
@@ -1162,7 +1468,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+      Return InternalOrderBy(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T9, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {8}, False)
     End Function
 
     ''' <summary>
@@ -1172,7 +1487,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+      Return InternalOrderBy(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T10, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {9}, False)
     End Function
 
     ''' <summary>
@@ -1182,7 +1506,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+      Return InternalOrderBy(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T11, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {10}, False)
     End Function
 
     ''' <summary>
@@ -1192,7 +1525,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+      Return InternalOrderBy(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T12, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {11}, False)
     End Function
 
     ''' <summary>
@@ -1202,7 +1544,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+      Return InternalOrderBy(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T13, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {12}, False)
     End Function
 
     ''' <summary>
@@ -1212,7 +1563,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+      Return InternalOrderBy(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T14, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {13}, False)
     End Function
 
     ''' <summary>
@@ -1222,7 +1582,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+      Return InternalOrderBy(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T15, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {14}, False)
     End Function
 
     ''' <summary>
@@ -1232,7 +1601,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+      Return InternalOrderBy(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T16, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {15}, False)
     End Function
 
     ''' <summary>
@@ -1242,7 +1620,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+      Return InternalOrderBy(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T17, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {16}, False)
     End Function
 
     ''' <summary>
@@ -1252,7 +1639,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+      Return InternalOrderBy(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T18, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {17}, False)
     End Function
 
     ''' <summary>
@@ -1262,7 +1658,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+      Return InternalOrderBy(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T19, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {18}, False)
     End Function
 
     ''' <summary>
@@ -1272,7 +1677,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+      Return InternalOrderBy(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T20, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {19}, False)
     End Function
 
     ''' <summary>
@@ -1282,7 +1696,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+      Return InternalOrderBy(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T21, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {20}, False)
     End Function
 
     ''' <summary>
@@ -1292,7 +1715,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+      Return InternalOrderBy(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T22, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {21}, False)
     End Function
 
     ''' <summary>
@@ -1302,7 +1734,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+      Return InternalOrderBy(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T23, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {22}, False)
     End Function
 
     ''' <summary>
@@ -1312,7 +1753,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+      Return InternalOrderBy(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T24, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {23}, False)
     End Function
 
     ''' <summary>
@@ -1322,7 +1772,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
+      Return InternalOrderBy(keySelector, {24}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T25, FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -1332,18 +1791,26 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Return InternalOrderBy(Of TKey)(keySelector, Nothing, False)
+      Return InternalOrderBy(keySelector, Nothing, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), FormattableString))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(keySelector, Nothing, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -50,6 +50,456 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="predicate"></param>
     ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T1, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T2, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T3, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T4, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T5, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T6, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T7, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T8, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T9, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T10, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T11, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T12, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T13, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T14, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T15, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T16, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T17, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T18, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T19, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T20, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T21, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T22, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T22, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T23, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T23, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T24, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T24, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T25, Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
+    Public Function Where(predicate As Expression(Of Func(Of T25, FormattableString))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalWhere(predicate, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds WHERE clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <returns></returns>
     Public Function Where(predicate As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), Boolean))) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalWhere(predicate, Nothing)
     End Function
@@ -99,6 +549,256 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalGroupBy(Of TKey)(keySelector, {24})
+    End Function
+
+    ''' <summary>
+    ''' Adds GROUP BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function GroupBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As GroupedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalGroupBy(Of TKey)(keySelector, Nothing)
     End Function
@@ -121,8 +821,508 @@ Namespace Expressions
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalOrderBy(Of TKey)(keySelector, Nothing, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T1, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T2, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {1}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T3, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {2}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T4, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {3}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T5, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {4}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T6, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {5}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T7, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {6}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T8, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {7}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T9, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {8}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T10, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {9}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T11, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {10}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T12, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {11}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T13, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {12}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T14, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {13}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T15, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {14}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T16, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {15}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T17, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {16}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T18, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {17}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T19, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {18}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T20, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {19}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T21, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {20}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T22, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {21}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T23, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {22}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T24, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {23}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <typeparam name="TKey"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T25, TKey))) As OrderedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalOrderBy(Of TKey)(keySelector, {24}, False)
     End Function
 
     ''' <summary>
@@ -195,6 +1395,256 @@ Namespace Expressions
       Me.Builder.AddSelectCount()
       Dim query = Me.Builder.CreateQuery()
       Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T8, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {7})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T9, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {8})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T10, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {9})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T11, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {10})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T12, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {11})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T13, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {12})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T14, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {13})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T15, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {14})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T16, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {15})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T17, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {16})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T18, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {17})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T19, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {18})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T20, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {19})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T21, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {20})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T22, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {21})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T23, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {22})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T24, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {23})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T25, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {24})
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -141,6 +141,326 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -160,6 +160,456 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -179,6 +179,608 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -33,6 +33,86 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -198,6 +198,782 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -34,6 +34,96 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -217,6 +217,978 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -236,6 +236,1196 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -35,6 +35,106 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -255,6 +255,1436 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -36,6 +36,116 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -274,6 +274,1698 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -37,6 +37,126 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -38,6 +38,136 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -293,6 +293,1982 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -39,6 +39,146 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -312,6 +312,2288 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -331,6 +331,2616 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -40,6 +40,156 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -41,6 +41,166 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -350,6 +350,2966 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -42,6 +42,176 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -369,6 +369,3338 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -43,6 +43,186 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -388,6 +388,3732 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(action, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -407,6 +407,4148 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(action, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -44,6 +44,196 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -426,6 +426,4586 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(action, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -45,6 +45,206 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -46,6 +46,216 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -445,6 +445,5046 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(action, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -464,6 +464,5528 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T22))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(action, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {0}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {1}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {2}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {3}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {4}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {5}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {6}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {7}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {8}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {9}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {10}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {11}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {12}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {13}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {14}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {15}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {16}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {17}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {18}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {19}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {20}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalInclude(keySelector, valueSelector, {21}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -47,6 +47,226 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -483,6 +483,6032 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T22))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T23))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(action, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {0}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {1}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {2}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {3}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {4}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {5}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {6}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {7}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {8}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {9}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {10}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {11}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {12}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {13}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {14}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {15}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {16}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {17}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {18}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {19}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {20}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {21}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalInclude(keySelector, valueSelector, {22}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -48,6 +48,236 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -502,6 +502,6558 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T22))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T23))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T24))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(action, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {0}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {1}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {2}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {3}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {4}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {5}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {6}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {7}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {8}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {9}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {10}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {11}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {12}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {13}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {14}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {15}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {16}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {17}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {18}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {19}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {20}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {21}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {22}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalInclude(keySelector, valueSelector, {23}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -49,6 +49,246 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -521,6 +521,7106 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="action"></param>
     ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T1))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T2))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T3))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T4))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T5))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T6))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T7))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T8))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T9))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T10))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T11))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T12))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T13))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T14))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T15))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T16))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T17))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T18))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T19))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T20))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T21))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T22))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T23))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T24))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
+    Public Function Include(action As Expression(Of Action(Of T25))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(action, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T1, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {0}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T2, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {1}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T3, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {2}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T4, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {3}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T5, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {4}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T6, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {5}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T7, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {6}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T8, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {7}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T9, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {8}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T10, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {9}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T11, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {10}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T12, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {11}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T13, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {12}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T14, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {13}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T15, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {14}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T16, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {15}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T17, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {16}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T18, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {17}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T19, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {18}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T20, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {19}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T21, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {20}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T22, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {21}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T23, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {22}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T24, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {23}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {0})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {1})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {2})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {3})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {4})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {5})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {6})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {7})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {8})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {9})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {10})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {11})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {12})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {13})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {14})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {15})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {16})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {17})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {18})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {19})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {20})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {21})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {22})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {23})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="keySelector"></param>
+    ''' <param name="valueSelector"></param>
+    ''' <returns></returns>
+    Public Function Include(Of TProperty)(keySelector As Expression(Of Func(Of T25, TProperty)), valueSelector As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalInclude(keySelector, valueSelector, {24}, {24})
+    End Function
+
+    ''' <summary>
+    ''' Includes &lt;column(s)&gt; to SELECT clause.
+    ''' </summary>
+    ''' <param name="action"></param>
+    ''' <returns></returns>
     Public Function Include(action As Expression(Of Action(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalInclude(action, Nothing)
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -50,6 +50,256 @@ Namespace Expressions
     ''' <typeparam name="TProperty"></typeparam>
     ''' <param name="propertyExpression"></param>
     ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T1, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T2, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T3, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T4, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T5, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T6, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T7, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T8, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T9, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T10, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T11, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T12, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T13, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T14, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T15, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T16, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T17, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T18, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T19, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T20, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T21, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T22, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T23, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T24, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
+    Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of T25, TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Return InternalExclude(propertyExpression)
+    End Function
+
+    ''' <summary>
+    ''' Excludes &lt;column&gt; from SELECT clause.
+    ''' </summary>
+    ''' <typeparam name="TProperty"></typeparam>
+    ''' <param name="propertyExpression"></param>
+    ''' <returns></returns>
     Public Function Exclude(Of TProperty)(propertyExpression As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25), TProperty))) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
       Return InternalExclude(propertyExpression)
     End Function

--- a/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
@@ -396,6 +396,17 @@ Namespace Expressions
     ''' <summary>
     ''' Adds ORDER BY DESC clause.
     ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, True, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
     ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
@@ -410,6 +421,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
       Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(predicate As String, ParamArray parameters() As Object) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(predicate, False, parameters)
+      Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
@@ -381,7 +381,16 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, True)
+      Return InternalOrderBy(keySelector, {0}, True)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderBy(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, True)
     End Function
 
     ''' <summary>
@@ -391,18 +400,27 @@ Namespace Expressions
     ''' <param name="keySelector"></param>
     ''' <returns></returns>
     Public Function OrderByDescending(Of TKey)(keySelector As Expression(Of Func(Of T, TKey))) As OrderedSelectSqlExpression(Of T)
-      Return InternalOrderBy(Of TKey)(keySelector, False)
+      Return InternalOrderBy(keySelector, {0}, False)
+    End Function
+
+    ''' <summary>
+    ''' Adds ORDER BY DESC clause.
+    ''' </summary>
+    ''' <param name="keySelector"></param>
+    ''' <returns></returns>
+    Public Function OrderByDescending(keySelector As Expression(Of Func(Of T, FormattableString))) As OrderedSelectSqlExpression(Of T)
+      Return InternalOrderBy(keySelector, {0}, False)
     End Function
 
     ''' <summary>
     ''' Adds ORDER BY clause.
     ''' </summary>
-    ''' <typeparam name="TKey"></typeparam>
     ''' <param name="keySelector"></param>
+    ''' <param name="entityIndexHints"></param>
     ''' <param name="ascending"></param>
     ''' <returns></returns>
-    Private Function InternalOrderBy(Of TKey)(keySelector As Expression(Of Func(Of T, TKey)), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
-      Me.Builder.AddOrderBy(keySelector, {0}, ascending)
+    Private Function InternalOrderBy(keySelector As Expression, entityIndexHints As Int32(), ascending As Boolean) As OrderedSelectSqlExpression(Of T)
+      Me.Builder.AddOrderBy(keySelector, entityIndexHints, ascending)
       Return New OrderedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Test/Yamo.Test/Tests/SelectWithSortTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithSortTests.vb
@@ -190,5 +190,49 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub SelectWithOrderByFormattableSqlString()
+      Dim label1En = Me.ModelFactory.CreateLabel("aaa", 1, English, "a")
+      Dim label2En = Me.ModelFactory.CreateLabel("aaa", 2, English, "b")
+      Dim label3En = Me.ModelFactory.CreateLabel("aaa", 3, English, "c")
+      Dim label4En = Me.ModelFactory.CreateLabel("bbb", 4, English, "a")
+      Dim label5En = Me.ModelFactory.CreateLabel("bbb", 5, English, "b")
+      Dim label6En = Me.ModelFactory.CreateLabel("bbb", 6, English, "c")
+
+      InsertItems(label1En, label2En, label3En, label4En, label5En, label6En)
+
+      Using db = CreateDbContext()
+        ' NOTE: DirectCast is needed (VB.NET compiler bug/feature?)
+        Dim result = db.From(Of Label).
+                        OrderBy(Function(x) DirectCast($"{x.TableId} DESC", FormattableString)).
+                        ThenBy(Function(x) DirectCast($"{x.Id} * -1", FormattableString)).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(6, result.Count)
+        Assert.AreEqual(label6En, result(0))
+        Assert.AreEqual(label5En, result(1))
+        Assert.AreEqual(label4En, result(2))
+        Assert.AreEqual(label3En, result(3))
+        Assert.AreEqual(label2En, result(4))
+        Assert.AreEqual(label1En, result(5))
+      End Using
+
+      Using db = CreateDbContext()
+        ' NOTE: DirectCast is needed (VB.NET compiler bug/feature?)
+        Dim result = db.From(Of Label).
+                        OrderByDescending(Function(x) DirectCast($"{x.TableId}", FormattableString)).
+                        ThenByDescending(Function(x) DirectCast($"{x.Id} * -1", FormattableString)).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(6, result.Count)
+        Assert.AreEqual(label4En, result(0))
+        Assert.AreEqual(label5En, result(1))
+        Assert.AreEqual(label6En, result(2))
+        Assert.AreEqual(label1En, result(3))
+        Assert.AreEqual(label2En, result(4))
+        Assert.AreEqual(label3En, result(5))
+      End Using
+    End Sub
+
   End Class
 End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectWithSortTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithSortTests.vb
@@ -234,5 +234,97 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub SelectWithOrderByRawSqlString()
+      Dim label1En = Me.ModelFactory.CreateLabel("aaa", 1, English, "a")
+      Dim label2En = Me.ModelFactory.CreateLabel("aaa", 2, English, "b")
+      Dim label3En = Me.ModelFactory.CreateLabel("aaa", 3, English, "c")
+      Dim label4En = Me.ModelFactory.CreateLabel("bbb", 4, English, "a")
+      Dim label5En = Me.ModelFactory.CreateLabel("bbb", 5, English, "b")
+      Dim label6En = Me.ModelFactory.CreateLabel("bbb", 6, English, "c")
+
+      InsertItems(label1En, label2En, label3En, label4En, label5En, label6En)
+
+      Using db = CreateDbContext()
+        ' NOTE: DirectCast is needed (VB.NET compiler bug/feature?)
+        Dim result = db.From(Of Label).
+                        OrderBy("TableId DESC").
+                        ThenBy("Id * -1").
+                        SelectAll().ToList()
+
+        Assert.AreEqual(6, result.Count)
+        Assert.AreEqual(label6En, result(0))
+        Assert.AreEqual(label5En, result(1))
+        Assert.AreEqual(label4En, result(2))
+        Assert.AreEqual(label3En, result(3))
+        Assert.AreEqual(label2En, result(4))
+        Assert.AreEqual(label1En, result(5))
+      End Using
+
+      Using db = CreateDbContext()
+        ' NOTE: DirectCast is needed (VB.NET compiler bug/feature?)
+        Dim result = db.From(Of Label).
+                        OrderByDescending("TableId").
+                        ThenByDescending("Id * -1").
+                        SelectAll().ToList()
+
+        Assert.AreEqual(6, result.Count)
+        Assert.AreEqual(label4En, result(0))
+        Assert.AreEqual(label5En, result(1))
+        Assert.AreEqual(label6En, result(2))
+        Assert.AreEqual(label1En, result(3))
+        Assert.AreEqual(label2En, result(4))
+        Assert.AreEqual(label3En, result(5))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithOrderByRawSqlStringWithParameters()
+      Dim label1En = Me.ModelFactory.CreateLabel("aaa", 1, English, "a")
+      Dim label2En = Me.ModelFactory.CreateLabel("aaa", 2, English, "b")
+      Dim label3En = Me.ModelFactory.CreateLabel("aaa", 3, English, "c")
+      Dim label4En = Me.ModelFactory.CreateLabel("bbb", 4, English, "a")
+      Dim label5En = Me.ModelFactory.CreateLabel("bbb", 5, English, "b")
+      Dim label6En = Me.ModelFactory.CreateLabel("bbb", 6, English, "c")
+
+      InsertItems(label1En, label2En, label3En, label4En, label5En, label6En)
+
+      Using db = CreateDbContext()
+        Dim tableIdColumn = db.Model.GetEntity(GetType(Label)).GetProperty(NameOf(Label.TableId)).ColumnName
+        Dim idColumn = db.Model.GetEntity(GetType(Label)).GetProperty(NameOf(Label.Id)).ColumnName
+
+        Dim result = db.From(Of Label).
+                        OrderBy("{0} DESC", RawSqlString.Create(tableIdColumn)).
+                        ThenBy("{0} * {1}", RawSqlString.Create(idColumn), -1).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(6, result.Count)
+        Assert.AreEqual(label6En, result(0))
+        Assert.AreEqual(label5En, result(1))
+        Assert.AreEqual(label4En, result(2))
+        Assert.AreEqual(label3En, result(3))
+        Assert.AreEqual(label2En, result(4))
+        Assert.AreEqual(label1En, result(5))
+      End Using
+
+      Using db = CreateDbContext()
+        Dim tableIdColumn = db.Model.GetEntity(GetType(Label)).GetProperty(NameOf(Label.TableId)).ColumnName
+        Dim idColumn = db.Model.GetEntity(GetType(Label)).GetProperty(NameOf(Label.Id)).ColumnName
+
+        Dim result = db.From(Of Label).
+                        OrderByDescending("{0}", RawSqlString.Create(tableIdColumn)).
+                        ThenByDescending("{0} * {1}", RawSqlString.Create(idColumn), -1).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(6, result.Count)
+        Assert.AreEqual(label4En, result(0))
+        Assert.AreEqual(label5En, result(1))
+        Assert.AreEqual(label6En, result(2))
+        Assert.AreEqual(label1En, result(3))
+        Assert.AreEqual(label2En, result(4))
+        Assert.AreEqual(label3En, result(5))
+      End Using
+    End Sub
+
   End Class
 End Namespace


### PR DESCRIPTION
This PR contains following expressions enhancements:
- Added overloads of expression methods for every joined entity. So far this was only available for selects with max 7 entities (otherwise, only methods with `IJoin` were available). This only affects methods with single entity parameter (`Where`, `And`, `OrderBy`, ...). Methods with multiple entities (`Join`, ...) were not added, since the number of combinations would be huge.
- Adds support for sorting by `FormattableString`.
- Adds support for sorting by raw SQL string.